### PR TITLE
Issue 13 slashing logic

### DIFF
--- a/src/IRegistry.sol
+++ b/src/IRegistry.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0 <0.9.0;
 
-import {BLS} from "./lib/BLS.sol";
-import {ISlasher} from "./ISlasher.sol";
+import { BLS } from "./lib/BLS.sol";
+import { ISlasher } from "./ISlasher.sol";
 
 interface IRegistry {
     // Structs
@@ -28,29 +28,14 @@ interface IRegistry {
     }
 
     // Events
-    event OperatorRegistered(
-        bytes32 registrationRoot,
-        uint256 collateral,
-        uint16 unregistrationDelay
-    );
+    event OperatorRegistered(bytes32 registrationRoot, uint256 collateral, uint16 unregistrationDelay);
     event OperatorUnregistered(bytes32 registrationRoot, uint32 unregisteredAt);
     event RegistrationSlashed(
-        bytes32 registrationRoot,
-        address challenger,
-        address withdrawalAddress,
-        Registration reg
+        bytes32 registrationRoot, address challenger, address withdrawalAddress, Registration reg
     );
     event OperatorDeleted(bytes32 registrationRoot);
-    event OperatorSlashed(
-        bytes32 registrationRoot,
-        uint256 slashAmountGwei,
-        BLS.G1Point validatorPubKey
-    );
-    event ValidatorRegistered(
-        uint256 leafIndex,
-        Registration reg,
-        bytes32 leaf
-    );
+    event OperatorSlashed(bytes32 registrationRoot, uint256 slashAmountGwei, BLS.G1Point validatorPubKey);
+    event ValidatorRegistered(uint256 leafIndex, Registration reg, bytes32 leaf);
 
     // Errors
     error InsufficientCollateral();
@@ -72,18 +57,15 @@ interface IRegistry {
     error FraudProofMerklePathInvalid();
     error FraudProofChallengeInvalid();
 
-    function register(
-        Registration[] calldata registrations,
-        address withdrawalAddress,
-        uint16 unregistrationDelay
-    ) external payable returns (bytes32 registrationRoot);
+    function register(Registration[] calldata registrations, address withdrawalAddress, uint16 unregistrationDelay)
+        external
+        payable
+        returns (bytes32 registrationRoot);
 
-    function verifyMerkleProof(
-        bytes32 registrationRoot,
-        bytes32 leaf,
-        bytes32[] calldata proof,
-        uint256 leafIndex
-    ) external view returns (uint256 collateralGwei);
+    function verifyMerkleProof(bytes32 registrationRoot, bytes32 leaf, bytes32[] calldata proof, uint256 leafIndex)
+        external
+        view
+        returns (uint256 collateralGwei);
 
     function slashRegistration(
         bytes32 registrationRoot,

--- a/src/IRegistry.sol
+++ b/src/IRegistry.sol
@@ -96,7 +96,7 @@ interface IRegistry {
 
     function claimCollateral(bytes32 registrationRoot) external;
 
-    function slashOperator(
+    function slashCommitment(
         bytes32 registrationRoot,
         BLS.G2Point calldata registrationSignature,
         bytes32[] calldata proof,

--- a/src/IRegistry.sol
+++ b/src/IRegistry.sol
@@ -33,6 +33,7 @@ interface IRegistry {
         bytes32 registrationRoot, address challenger, address withdrawalAddress, Registration reg
     );
     event OperatorDeleted(bytes32 registrationRoot);
+    event OperatorSlashed(bytes32 registrationRoot, uint256 slashAmountGwei, BLS.G1Point validatorPubKey);
     event ValidatorRegistered(uint256 leafIndex, Registration reg, bytes32 leaf);
 
     // Errors
@@ -47,6 +48,10 @@ interface IRegistry {
     error UnregistrationDelayNotMet();
     error NoCollateralToClaim();
     error FraudProofWindowExpired();
+    error FraudProofWindowNotMet();
+    error DelegationSignatureInvalid();
+    error SlashAmountExceedsCollateral();
+    error NoCollateralSlashed();
     error NotRegisteredValidator();
     error FraudProofMerklePathInvalid();
     error FraudProofChallengeInvalid();

--- a/src/IRegistry.sol
+++ b/src/IRegistry.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0 <0.9.0;
 
-import { BLS } from "./lib/BLS.sol";
+import {BLS} from "./lib/BLS.sol";
+import {ISlasher} from "./ISlasher.sol";
 
 interface IRegistry {
     // Structs
@@ -27,14 +28,29 @@ interface IRegistry {
     }
 
     // Events
-    event OperatorRegistered(bytes32 registrationRoot, uint256 collateral, uint16 unregistrationDelay);
+    event OperatorRegistered(
+        bytes32 registrationRoot,
+        uint256 collateral,
+        uint16 unregistrationDelay
+    );
     event OperatorUnregistered(bytes32 registrationRoot, uint32 unregisteredAt);
     event RegistrationSlashed(
-        bytes32 registrationRoot, address challenger, address withdrawalAddress, Registration reg
+        bytes32 registrationRoot,
+        address challenger,
+        address withdrawalAddress,
+        Registration reg
     );
     event OperatorDeleted(bytes32 registrationRoot);
-    event OperatorSlashed(bytes32 registrationRoot, uint256 slashAmountGwei, BLS.G1Point validatorPubKey);
-    event ValidatorRegistered(uint256 leafIndex, Registration reg, bytes32 leaf);
+    event OperatorSlashed(
+        bytes32 registrationRoot,
+        uint256 slashAmountGwei,
+        BLS.G1Point validatorPubKey
+    );
+    event ValidatorRegistered(
+        uint256 leafIndex,
+        Registration reg,
+        bytes32 leaf
+    );
 
     // Errors
     error InsufficientCollateral();
@@ -56,10 +72,18 @@ interface IRegistry {
     error FraudProofMerklePathInvalid();
     error FraudProofChallengeInvalid();
 
-    function register(Registration[] calldata registrations, address withdrawalAddress, uint16 unregistrationDelay)
-        external
-        payable
-        returns (bytes32 registrationRoot);
+    function register(
+        Registration[] calldata registrations,
+        address withdrawalAddress,
+        uint16 unregistrationDelay
+    ) external payable returns (bytes32 registrationRoot);
+
+    function verifyMerkleProof(
+        bytes32 registrationRoot,
+        bytes32 leaf,
+        bytes32[] calldata proof,
+        uint256 leafIndex
+    ) external view returns (uint256 collateralGwei);
 
     function slashRegistration(
         bytes32 registrationRoot,
@@ -71,4 +95,13 @@ interface IRegistry {
     function unregister(bytes32 registrationRoot) external;
 
     function claimCollateral(bytes32 registrationRoot) external;
+
+    function slashOperator(
+        bytes32 registrationRoot,
+        BLS.G2Point calldata registrationSignature,
+        bytes32[] calldata proof,
+        uint256 leafIndex,
+        ISlasher.SignedDelegation calldata signedDelegation,
+        bytes calldata evidence
+    ) external returns (uint256 slashAmountGwei);
 }

--- a/src/ISlasher.sol
+++ b/src/ISlasher.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0 <0.9.0;
 
-import {BLS} from "./lib/BLS.sol";
+import { BLS } from "./lib/BLS.sol";
 
 interface ISlasher {
     struct Delegation {
@@ -16,7 +16,9 @@ interface ISlasher {
         BLS.G2Point signature;
     }
 
-    function slash(Delegation calldata delegation, bytes calldata evidence) external returns (uint256 slashAmountGwei);
+    function slash(Delegation calldata delegation, bytes calldata evidence)
+        external
+        returns (uint256 slashAmountGwei);
 
     function DOMAIN_SEPARATOR() external view returns (bytes memory);
 }

--- a/src/ISlasher.sol
+++ b/src/ISlasher.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0 <0.9.0;
+
+import {BLS} from "./lib/BLS.sol";
+
+interface ISlasher {
+    struct Delegation {
+        BLS.G1Point validatorPubKey;
+        BLS.G1Point delegatePubKey;
+        address slasher;
+        bytes metadata;
+    }
+
+    struct SignedDelegation {
+        Delegation delegation;
+        BLS.G2Point signature;
+    }
+
+    function slash(Delegation calldata delegation, bytes calldata evidence) external returns (uint256 slashAmountGwei);
+}

--- a/src/ISlasher.sol
+++ b/src/ISlasher.sol
@@ -17,4 +17,6 @@ interface ISlasher {
     }
 
     function slash(Delegation calldata delegation, bytes calldata evidence) external returns (uint256 slashAmountGwei);
+
+    function DOMAIN_SEPARATOR() external view returns (bytes memory);
 }

--- a/src/Registry.sol
+++ b/src/Registry.sol
@@ -15,9 +15,8 @@ contract Registry is IRegistry {
     // Constants
     uint256 public constant MIN_COLLATERAL = 0.1 ether;
     uint256 public constant MIN_UNREGISTRATION_DELAY = 64; // Two epochs
-    uint256 public constant FRAUD_PROOF_WINDOW = 7200;
-    bytes public constant DOMAIN_SEPARATOR =
-        bytes("Universal-Registry-Contract");
+    uint256 public constant FRAUD_PROOF_WINDOW = 7200;     // 1 day
+    bytes public constant DOMAIN_SEPARATOR = "0x00435255"; // "URC" in little endian
 
     function register(
         Registration[] calldata regs,

--- a/src/Registry.sol
+++ b/src/Registry.sol
@@ -185,7 +185,7 @@ contract Registry is IRegistry {
         delete registrations[registrationRoot];
     }
 
-    function slashOperator(
+    function slashCommitment(
         bytes32 registrationRoot,
         BLS.G2Point calldata registrationSignature,
         bytes32[] calldata proof,

--- a/test/Registry.t.sol
+++ b/test/Registry.t.sol
@@ -5,7 +5,7 @@ import "forge-std/Test.sol";
 import "../src/Registry.sol";
 import "../src/IRegistry.sol";
 import { BLS } from "../src/lib/BLS.sol";
-import {UnitTestHelper} from "./UnitTestHelper.sol";
+import { UnitTestHelper } from "./UnitTestHelper.sol";
 
 contract RegistryTest is UnitTestHelper {
     using BLS for *;
@@ -438,13 +438,14 @@ contract RegistryTest is UnitTestHelper {
 
     function test_unregister() public {
         (uint16 unregistrationDelay, uint256 collateral) = _setupBasicRegistrationParams();
-        IRegistry.Registration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, alice, unregistrationDelay);
-        
+        IRegistry.Registration[] memory registrations =
+            _setupSingleRegistration(SECRET_KEY_1, alice, unregistrationDelay);
+
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, alice, unregistrationDelay);
-        
+
         vm.prank(alice);
         registry.unregister(registrationRoot);
-        
+
         (,, uint32 registeredAt, uint32 unregisteredAt,) = registry.registrations(registrationRoot);
         assertEq(unregisteredAt, uint32(block.number), "Wrong unregistration block");
         assertEq(registeredAt, uint32(block.number), "Wrong registration block"); // Should remain unchanged
@@ -452,10 +453,11 @@ contract RegistryTest is UnitTestHelper {
 
     function test_unregister_wrongOperator() public {
         (uint16 unregistrationDelay, uint256 collateral) = _setupBasicRegistrationParams();
-        IRegistry.Registration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, alice, unregistrationDelay);
-        
+        IRegistry.Registration[] memory registrations =
+            _setupSingleRegistration(SECRET_KEY_1, alice, unregistrationDelay);
+
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, alice, unregistrationDelay);
-        
+
         // Bob tries to unregister Alice's registration
         vm.prank(bob);
         vm.expectRevert(IRegistry.WrongOperator.selector);
@@ -464,13 +466,14 @@ contract RegistryTest is UnitTestHelper {
 
     function test_unregister_alreadyUnregistered() public {
         (uint16 unregistrationDelay, uint256 collateral) = _setupBasicRegistrationParams();
-        IRegistry.Registration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, alice, unregistrationDelay);
-        
+        IRegistry.Registration[] memory registrations =
+            _setupSingleRegistration(SECRET_KEY_1, alice, unregistrationDelay);
+
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, alice, unregistrationDelay);
-        
+
         vm.prank(alice);
         registry.unregister(registrationRoot);
-        
+
         // Try to unregister again
         vm.prank(alice);
         vm.expectRevert(IRegistry.AlreadyUnregistered.selector);
@@ -479,23 +482,24 @@ contract RegistryTest is UnitTestHelper {
 
     function test_claimCollateral() public {
         (uint16 unregistrationDelay, uint256 collateral) = _setupBasicRegistrationParams();
-        IRegistry.Registration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, alice, unregistrationDelay);
-        
+        IRegistry.Registration[] memory registrations =
+            _setupSingleRegistration(SECRET_KEY_1, alice, unregistrationDelay);
+
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, alice, unregistrationDelay);
-        
+
         vm.prank(alice);
         registry.unregister(registrationRoot);
-        
+
         // Wait for unregistration delay
         vm.roll(block.number + unregistrationDelay);
-        
+
         uint256 balanceBefore = alice.balance;
-        
+
         vm.prank(alice);
         registry.claimCollateral(registrationRoot);
-        
+
         assertEq(alice.balance, balanceBefore + collateral, "Collateral not returned");
-        
+
         // Verify registration was deleted
         (address withdrawalAddress,,,,) = registry.registrations(registrationRoot);
         assertEq(withdrawalAddress, address(0), "Registration not deleted");
@@ -503,10 +507,11 @@ contract RegistryTest is UnitTestHelper {
 
     function test_claimCollateral_notUnregistered() public {
         (uint16 unregistrationDelay, uint256 collateral) = _setupBasicRegistrationParams();
-        IRegistry.Registration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, alice, unregistrationDelay);
-        
+        IRegistry.Registration[] memory registrations =
+            _setupSingleRegistration(SECRET_KEY_1, alice, unregistrationDelay);
+
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, alice, unregistrationDelay);
-        
+
         // Try to claim without unregistering first
         vm.prank(alice);
         vm.expectRevert(IRegistry.NotUnregistered.selector);
@@ -515,16 +520,17 @@ contract RegistryTest is UnitTestHelper {
 
     function test_claimCollateral_delayNotMet() public {
         (uint16 unregistrationDelay, uint256 collateral) = _setupBasicRegistrationParams();
-        IRegistry.Registration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, alice, unregistrationDelay);
-        
+        IRegistry.Registration[] memory registrations =
+            _setupSingleRegistration(SECRET_KEY_1, alice, unregistrationDelay);
+
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, alice, unregistrationDelay);
-        
+
         vm.prank(alice);
         registry.unregister(registrationRoot);
-        
+
         // Try to claim before delay has passed
         vm.roll(block.number + unregistrationDelay - 1);
-        
+
         vm.prank(alice);
         vm.expectRevert(IRegistry.UnregistrationDelayNotMet.selector);
         registry.claimCollateral(registrationRoot);
@@ -532,18 +538,19 @@ contract RegistryTest is UnitTestHelper {
 
     function test_claimCollateral_alreadyClaimed() public {
         (uint16 unregistrationDelay, uint256 collateral) = _setupBasicRegistrationParams();
-        IRegistry.Registration[] memory registrations = _setupSingleRegistration(SECRET_KEY_1, alice, unregistrationDelay);
-        
+        IRegistry.Registration[] memory registrations =
+            _setupSingleRegistration(SECRET_KEY_1, alice, unregistrationDelay);
+
         bytes32 registrationRoot = registry.register{ value: collateral }(registrations, alice, unregistrationDelay);
-        
+
         vm.prank(alice);
         registry.unregister(registrationRoot);
-        
+
         vm.roll(block.number + unregistrationDelay);
-        
+
         vm.prank(alice);
         registry.claimCollateral(registrationRoot);
-        
+
         // Try to claim again
         vm.prank(alice);
         vm.expectRevert(IRegistry.NotUnregistered.selector);

--- a/test/Registry.t.sol
+++ b/test/Registry.t.sol
@@ -17,16 +17,8 @@ contract RegistryTest is UnitTestHelper {
     }
 
     function test_register() public {
-        (uint16 unregistrationDelay, uint256 collateral) = _setupBasicRegistrationParams();
-
-        IRegistry.Registration[] memory registrations =
-            _setupSingleRegistration(SECRET_KEY_1, alice, unregistrationDelay);
-
-        bytes32 registrationRoot = registry.register{ value: collateral }(registrations, alice, unregistrationDelay);
-
-        _assertRegistration(
-            registrationRoot, alice, uint56(collateral / 1 gwei), uint32(block.number), 0, unregistrationDelay
-        );
+        uint256 collateral = registry.MIN_COLLATERAL();
+        basicRegistration(SECRET_KEY_1, collateral, alice);
     }
 
     function test_register_insufficientCollateral() public {

--- a/test/Registry.t.sol
+++ b/test/Registry.t.sol
@@ -191,7 +191,7 @@ contract RegistryTest is Test {
 
         uint256 gotCollateral = registry.verifyMerkleProof(
             registrationRoot,
-            registrations[0],
+            leaves[0],
             proof,
             0 // leafIndex
         );
@@ -307,13 +307,13 @@ contract RegistryTest is Test {
         // Test first proof path
         uint256 leafIndex = 0;
         bytes32[] memory proof = MerkleTree.generateProof(leaves, leafIndex);
-        uint256 gotCollateral = registry.verifyMerkleProof(registrationRoot, registrations[0], proof, leafIndex);
+        uint256 gotCollateral = registry.verifyMerkleProof(registrationRoot, leaves[0], proof, leafIndex);
         assertEq(gotCollateral, uint56(collateral / 1 gwei), "Wrong collateral amount");
 
         // Test second proof path
         leafIndex = 1;
         proof = MerkleTree.generateProof(leaves, leafIndex);
-        gotCollateral = registry.verifyMerkleProof(registrationRoot, registrations[1], proof, leafIndex);
+        gotCollateral = registry.verifyMerkleProof(registrationRoot, leaves[1], proof, leafIndex);
         assertEq(gotCollateral, uint56(collateral / 1 gwei), "Wrong collateral amount");
     }
 
@@ -418,7 +418,7 @@ contract RegistryTest is Test {
         // Test all proof paths
         for (uint256 i = 0; i < leaves.length; i++) {
             bytes32[] memory proof = MerkleTree.generateProof(leaves, i);
-            uint256 gotCollateral = registry.verifyMerkleProof(registrationRoot, registrations[i], proof, i);
+            uint256 gotCollateral = registry.verifyMerkleProof(registrationRoot, leaves[i], proof, i);
             assertEq(gotCollateral, uint56(collateral / 1 gwei), "Wrong collateral amount");
         }
     }
@@ -440,7 +440,7 @@ contract RegistryTest is Test {
         // Test all proof paths
         for (uint256 i = 0; i < leaves.length; i++) {
             bytes32[] memory proof = MerkleTree.generateProof(leaves, i);
-            uint256 gotCollateral = registry.verifyMerkleProof(registrationRoot, registrations[i], proof, i);
+            uint256 gotCollateral = registry.verifyMerkleProof(registrationRoot, leaves[i], proof, i);
             assertEq(gotCollateral, uint56(collateral / 1 gwei), "Wrong collateral amount");
         }
     }
@@ -652,4 +652,9 @@ contract RegistryTest is Test {
         vm.expectRevert(IRegistry.NotUnregistered.selector);
         registry.claimCollateral(registrationRoot);
     }
+}
+
+
+contract RegistrySlasherTest is Test {
+
 }

--- a/test/Registry.t.sol
+++ b/test/Registry.t.sol
@@ -5,110 +5,15 @@ import "forge-std/Test.sol";
 import "../src/Registry.sol";
 import "../src/IRegistry.sol";
 import { BLS } from "../src/lib/BLS.sol";
+import {UnitTestHelper} from "./UnitTestHelper.sol";
 
-contract RegistryTest is Test {
+contract RegistryTest is UnitTestHelper {
     using BLS for *;
-
-    Registry registry;
-    address alice = makeAddr("alice");
-    address bob = makeAddr("bob");
-
-    // Preset secret keys for deterministic testing
-    uint256 constant SECRET_KEY_1 = 12345;
-    uint256 constant SECRET_KEY_2 = 67890;
 
     function setUp() public {
         registry = new Registry();
         vm.deal(alice, 100 ether); // Give alice some ETH
         vm.deal(bob, 100 ether); // Give bob some ETH
-    }
-
-    /// @dev Helper to create a BLS signature for a registration
-    function _registrationSignature(uint256 secretKey, address withdrawalAddress, uint16 unregistrationDelay)
-        internal
-        view
-        returns (BLS.G2Point memory)
-    {
-        bytes memory message = abi.encodePacked(withdrawalAddress, unregistrationDelay);
-        return BLS.sign(message, secretKey, registry.DOMAIN_SEPARATOR());
-    }
-
-    /// @dev Creates a Registration struct with a real BLS keypair
-    function _createRegistration(uint256 secretKey, address withdrawalAddress, uint16 unregistrationDelay)
-        internal
-        view
-        returns (IRegistry.Registration memory)
-    {
-        BLS.G1Point memory pubkey = BLS.toPublicKey(secretKey);
-        BLS.G2Point memory signature = _registrationSignature(secretKey, withdrawalAddress, unregistrationDelay);
-
-        return IRegistry.Registration({ pubkey: pubkey, signature: signature });
-    }
-
-    /// @dev Helper to verify operator data matches expected values
-    function _assertRegistration(
-        bytes32 registrationRoot,
-        address expectedWithdrawalAddress,
-        uint56 expectedCollateral,
-        uint32 expectedRegisteredAt,
-        uint32 expectedUnregisteredAt,
-        uint16 expectedUnregistrationDelay
-    ) internal view {
-        (
-            address withdrawalAddress,
-            uint56 collateral,
-            uint32 registeredAt,
-            uint32 unregisteredAt,
-            uint16 unregistrationDelay
-        ) = registry.registrations(registrationRoot);
-
-        assertEq(withdrawalAddress, expectedWithdrawalAddress, "Wrong withdrawal address");
-        assertEq(collateral, expectedCollateral, "Wrong collateral amount");
-        assertEq(registeredAt, expectedRegisteredAt, "Wrong registration block");
-        assertEq(unregisteredAt, expectedUnregisteredAt, "Wrong unregistration block");
-        assertEq(unregistrationDelay, expectedUnregistrationDelay, "Wrong unregistration delay");
-    }
-
-    function _hashToLeaves(IRegistry.Registration[] memory registrations) internal pure returns (bytes32[] memory) {
-        bytes32[] memory leaves = new bytes32[](registrations.length);
-        for (uint256 i = 0; i < registrations.length; i++) {
-            leaves[i] = keccak256(abi.encode(registrations[i]));
-        }
-        return leaves;
-    }
-
-    // New helper functions
-    function _setupBasicRegistrationParams() internal view returns (uint16 unregistrationDelay, uint256 collateral) {
-        unregistrationDelay = uint16(registry.MIN_UNREGISTRATION_DELAY());
-        collateral = registry.MIN_COLLATERAL();
-    }
-
-    function _setupSingleRegistration(uint256 secretKey, address withdrawalAddr, uint16 unregistrationDelay)
-        internal
-        view
-        returns (IRegistry.Registration[] memory)
-    {
-        IRegistry.Registration[] memory registrations = new IRegistry.Registration[](1);
-        registrations[0] = _createRegistration(secretKey, withdrawalAddr, unregistrationDelay);
-        return registrations;
-    }
-
-    function _verifySlashingBalances(
-        address challenger,
-        address operator,
-        uint256 slashedAmount,
-        uint256 totalCollateral,
-        uint256 challengerBalanceBefore,
-        uint256 operatorBalanceBefore,
-        uint256 urcBalanceBefore
-    ) internal view {
-        assertEq(challenger.balance, challengerBalanceBefore + slashedAmount, "challenger didn't receive reward");
-        assertEq(
-            operator.balance,
-            operatorBalanceBefore + totalCollateral - slashedAmount,
-            "operator didn't receive remaining funds"
-        );
-        assertEq(address(registry).balance, urcBalanceBefore - totalCollateral, "urc balance incorrect");
     }
 
     function test_register() public {
@@ -652,9 +557,4 @@ contract RegistryTest is Test {
         vm.expectRevert(IRegistry.NotUnregistered.selector);
         registry.claimCollateral(registrationRoot);
     }
-}
-
-
-contract RegistrySlasherTest is Test {
-
 }

--- a/test/Slasher.t.sol
+++ b/test/Slasher.t.sol
@@ -71,6 +71,9 @@ contract DummySlasherTest is UnitTestHelper {
 
         // slash from a different address
         vm.prank(bob);
+        vm.expectEmit(address(registry));
+        emit IRegistry.OperatorSlashed(result.registrationRoot, slashAmountGwei, result.signedDelegation.delegation.validatorPubKey);
+        emit IRegistry.OperatorDeleted(result.registrationRoot);
         uint256 gotSlashAmountGwei = registry.slashCommitment(
             result.registrationRoot,
             result.registrations[leafIndex].signature,
@@ -91,5 +94,224 @@ contract DummySlasherTest is UnitTestHelper {
             aliceBalanceBefore,
             urcBalanceBefore
         );
+
+        // Verify operator was deleted
+        _assertRegistration(result.registrationRoot, address(0), 0, 0, 0, 0);
+    }
+
+    function testRevertFraudProofWindowNotMet() public {
+        uint256 slashAmountGwei = 42;
+        dummySlasher = new DummySlasher(slashAmountGwei);
+
+        RegisterAndDelegateParams memory params = RegisterAndDelegateParams({
+            validatorSecretKey: SECRET_KEY_1,
+            collateral: collateral,
+            withdrawalAddress: alice,
+            delegateSecretKey: SECRET_KEY_2,
+            slasher: address(dummySlasher),
+            domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
+            metadata: ""
+        });
+
+        RegisterAndDelegateResult memory result = registerAndDelegate(params);
+
+        bytes32[] memory leaves = _hashToLeaves(result.registrations);
+        uint256 leafIndex = 0;
+        bytes32[] memory proof = MerkleTree.generateProof(leaves, leafIndex);
+        bytes memory evidence = "";
+
+        // Try to slash before fraud proof window expires
+        vm.expectRevert(IRegistry.FraudProofWindowNotMet.selector);
+        registry.slashCommitment(
+            result.registrationRoot,
+            result.registrations[leafIndex].signature,
+            proof,
+            leafIndex,
+            result.signedDelegation,
+            evidence
+        );
+    }
+
+    function testRevertNotRegisteredValidator() public {
+        uint256 slashAmountGwei = 42;
+        dummySlasher = new DummySlasher(slashAmountGwei);
+
+        RegisterAndDelegateParams memory params = RegisterAndDelegateParams({
+            validatorSecretKey: SECRET_KEY_1,
+            collateral: collateral,
+            withdrawalAddress: alice,
+            delegateSecretKey: SECRET_KEY_2,
+            slasher: address(dummySlasher),
+            domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
+            metadata: ""
+        });
+
+        RegisterAndDelegateResult memory result = registerAndDelegate(params);
+
+        // Create invalid proof
+        bytes32[] memory invalidProof = new bytes32[](1);
+        invalidProof[0] = bytes32(0);
+
+        vm.roll(block.timestamp + registry.FRAUD_PROOF_WINDOW() + 1);
+
+        vm.expectRevert(IRegistry.NotRegisteredValidator.selector);
+        registry.slashCommitment(
+            result.registrationRoot,
+            result.registrations[0].signature,
+            invalidProof,
+            0,
+            result.signedDelegation,
+            ""
+        );
+    }
+
+    function testRevertDelegationSignatureInvalid() public {
+        uint256 slashAmountGwei = 42;
+        dummySlasher = new DummySlasher(slashAmountGwei);
+
+        RegisterAndDelegateParams memory params = RegisterAndDelegateParams({
+            validatorSecretKey: SECRET_KEY_1,
+            collateral: collateral,
+            withdrawalAddress: alice,
+            delegateSecretKey: SECRET_KEY_2,
+            slasher: address(dummySlasher),
+            domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
+            metadata: ""
+        });
+
+        RegisterAndDelegateResult memory result = registerAndDelegate(params);
+
+        // Sign delegation with different secret key
+        ISlasher.SignedDelegation memory badSignedDelegation = signDelegation(
+            SECRET_KEY_2,
+            result.signedDelegation.delegation,
+            params.domainSeparator
+        );
+
+        bytes32[] memory leaves = _hashToLeaves(result.registrations);
+        uint256 leafIndex = 0;
+        bytes32[] memory proof = MerkleTree.generateProof(leaves, leafIndex);
+
+        vm.roll(block.timestamp + registry.FRAUD_PROOF_WINDOW() + 1);
+
+        vm.expectRevert(IRegistry.DelegationSignatureInvalid.selector);
+        registry.slashCommitment(
+            result.registrationRoot,
+            result.registrations[leafIndex].signature,
+            proof,
+            leafIndex,
+            badSignedDelegation,
+            ""
+        );
+    }
+
+    function testRevertNoCollateralSlashed() public {
+        // Create DummySlasher that returns 0 slash amount
+        dummySlasher = new DummySlasher(0);
+
+        RegisterAndDelegateParams memory params = RegisterAndDelegateParams({
+            validatorSecretKey: SECRET_KEY_1,
+            collateral: collateral,
+            withdrawalAddress: alice,
+            delegateSecretKey: SECRET_KEY_2,
+            slasher: address(dummySlasher),
+            domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
+            metadata: ""
+        });
+
+        RegisterAndDelegateResult memory result = registerAndDelegate(params);
+
+        bytes32[] memory leaves = _hashToLeaves(result.registrations);
+        uint256 leafIndex = 0;
+        bytes32[] memory proof = MerkleTree.generateProof(leaves, leafIndex);
+
+        vm.roll(block.timestamp + registry.FRAUD_PROOF_WINDOW() + 1);
+
+        vm.expectRevert(IRegistry.NoCollateralSlashed.selector);
+        registry.slashCommitment(
+            result.registrationRoot,
+            result.registrations[leafIndex].signature,
+            proof,
+            leafIndex,
+            result.signedDelegation,
+            ""
+        );
+    }
+
+    function testRevertSlashAmountExceedsCollateral() public {
+        // Create DummySlasher that returns more than collateral
+        uint256 excessiveSlashAmount = collateral / 1 gwei + 1;
+        dummySlasher = new DummySlasher(excessiveSlashAmount);
+
+        RegisterAndDelegateParams memory params = RegisterAndDelegateParams({
+            validatorSecretKey: SECRET_KEY_1,
+            collateral: collateral,
+            withdrawalAddress: alice,
+            delegateSecretKey: SECRET_KEY_2,
+            slasher: address(dummySlasher),
+            domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
+            metadata: ""
+        });
+
+        RegisterAndDelegateResult memory result = registerAndDelegate(params);
+
+        bytes32[] memory leaves = _hashToLeaves(result.registrations);
+        uint256 leafIndex = 0;
+        bytes32[] memory proof = MerkleTree.generateProof(leaves, leafIndex);
+
+        vm.roll(block.timestamp + registry.FRAUD_PROOF_WINDOW() + 1);
+
+        vm.expectRevert(IRegistry.SlashAmountExceedsCollateral.selector);
+        registry.slashCommitment(
+            result.registrationRoot,
+            result.registrations[leafIndex].signature,
+            proof,
+            leafIndex,
+            result.signedDelegation,
+            ""
+        );
+    }
+
+    function testRevertEthTransferFailed() public {
+        uint256 slashAmountGwei = 42;
+        dummySlasher = new DummySlasher(slashAmountGwei);
+
+        // Deploy a contract that rejects ETH transfers
+        RejectEther rejectEther = new RejectEther();
+
+        RegisterAndDelegateParams memory params = RegisterAndDelegateParams({
+            validatorSecretKey: SECRET_KEY_1,
+            collateral: collateral,
+            withdrawalAddress: address(rejectEther),
+            delegateSecretKey: SECRET_KEY_2,
+            slasher: address(dummySlasher),
+            domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
+            metadata: ""
+        });
+
+        RegisterAndDelegateResult memory result = registerAndDelegate(params);
+
+        bytes32[] memory leaves = _hashToLeaves(result.registrations);
+        uint256 leafIndex = 0;
+        bytes32[] memory proof = MerkleTree.generateProof(leaves, leafIndex);
+
+        vm.roll(block.timestamp + registry.FRAUD_PROOF_WINDOW() + 1);
+
+        vm.expectRevert(IRegistry.EthTransferFailed.selector);
+        registry.slashCommitment(
+            result.registrationRoot,
+            result.registrations[leafIndex].signature,
+            proof,
+            leafIndex,
+            result.signedDelegation,
+            ""
+        );
+    }
+}
+
+// Helper contract that rejects ETH transfers
+contract RejectEther {
+    receive() external payable {
+        revert("No ETH accepted");
     }
 }

--- a/test/Slasher.t.sol
+++ b/test/Slasher.t.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0 <0.9.0;
+
+import "forge-std/Test.sol";
+import "forge-std/console.sol";
+import {BLS} from "../src/lib/BLS.sol";
+import {MerkleTree} from "../src/lib/MerkleTree.sol";
+import "../src/Registry.sol";
+import {IRegistry} from "../src/IRegistry.sol";
+import {ISlasher} from "../src/ISlasher.sol";
+import {UnitTestHelper} from "./UnitTestHelper.sol";
+
+contract DummySlasher is ISlasher {
+    uint256 public SLASH_AMOUNT_GWEI;
+
+    constructor(uint256 slashAmountGwei) {
+        SLASH_AMOUNT_GWEI = slashAmountGwei;
+    }
+
+    function DOMAIN_SEPARATOR() external view returns (bytes memory) {
+        return bytes("DUMMY-SLASHER-DOMAIN-SEPARATOR");
+    }
+
+    function slash(
+        ISlasher.Delegation calldata delegation,
+        bytes calldata evidence
+    ) external returns (uint256 slashAmountGwei) {
+        slashAmountGwei = SLASH_AMOUNT_GWEI;
+    }
+}
+
+contract DummySlasherTest is UnitTestHelper {
+    DummySlasher dummySlasher;
+    BLS.G1Point delegatePubKey;
+    uint256 collateral = 100 ether;
+
+    function setUp() public {
+        registry = new Registry();
+        vm.deal(alice, 100 ether); // Give alice some ETH
+        delegatePubKey = BLS.toPublicKey(SECRET_KEY_2);
+    }
+
+    function testDummySlasherUpdatesRegistry() public {
+        uint256 slashAmountGwei = 42;
+        dummySlasher = new DummySlasher(slashAmountGwei);
+
+        RegisterAndDelegateParams memory params = RegisterAndDelegateParams({
+            validatorSecretKey: SECRET_KEY_1,
+            collateral: collateral,
+            withdrawalAddress: alice,
+            delegateSecretKey: SECRET_KEY_2,
+            slasher: address(dummySlasher),
+            domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
+            metadata: ""
+        });
+
+        RegisterAndDelegateResult memory result = registerAndDelegate(params);
+
+        // Setup proof
+        bytes32[] memory leaves = _hashToLeaves(result.registrations);
+        uint256 leafIndex = 0;
+        bytes32[] memory proof = MerkleTree.generateProof(leaves, leafIndex);
+        bytes memory evidence = "";
+
+        // skip past fraud proof window
+        vm.roll(block.timestamp + registry.FRAUD_PROOF_WINDOW() + 1);
+
+        uint256 bobBalanceBefore = bob.balance;
+        uint256 aliceBalanceBefore = alice.balance;
+        uint256 urcBalanceBefore = address(registry).balance;
+
+        // slash from a different address
+        vm.prank(bob);
+        uint256 gotSlashAmountGwei = registry.slashOperator(
+            result.registrationRoot,
+            result.registrations[leafIndex].signature,
+            proof,
+            leafIndex,
+            result.signedDelegation,
+            evidence
+        );
+        assertEq(slashAmountGwei, gotSlashAmountGwei, "Slash amount incorrect");
+
+        // verify balances updated correctly
+        _verifySlashingBalances(
+            bob,
+            alice,
+            slashAmountGwei * 1 gwei,
+            collateral,
+            bobBalanceBefore,
+            aliceBalanceBefore,
+            urcBalanceBefore
+        );
+    }
+}

--- a/test/Slasher.t.sol
+++ b/test/Slasher.t.sol
@@ -71,7 +71,7 @@ contract DummySlasherTest is UnitTestHelper {
 
         // slash from a different address
         vm.prank(bob);
-        uint256 gotSlashAmountGwei = registry.slashOperator(
+        uint256 gotSlashAmountGwei = registry.slashCommitment(
             result.registrationRoot,
             result.registrations[leafIndex].signature,
             proof,

--- a/test/Slasher.t.sol
+++ b/test/Slasher.t.sol
@@ -3,12 +3,12 @@ pragma solidity >=0.8.0 <0.9.0;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";
-import {BLS} from "../src/lib/BLS.sol";
-import {MerkleTree} from "../src/lib/MerkleTree.sol";
+import { BLS } from "../src/lib/BLS.sol";
+import { MerkleTree } from "../src/lib/MerkleTree.sol";
 import "../src/Registry.sol";
-import {IRegistry} from "../src/IRegistry.sol";
-import {ISlasher} from "../src/ISlasher.sol";
-import {UnitTestHelper} from "./UnitTestHelper.sol";
+import { IRegistry } from "../src/IRegistry.sol";
+import { ISlasher } from "../src/ISlasher.sol";
+import { UnitTestHelper } from "./UnitTestHelper.sol";
 
 contract DummySlasher is ISlasher {
     uint256 public SLASH_AMOUNT_GWEI;
@@ -21,10 +21,10 @@ contract DummySlasher is ISlasher {
         return bytes("DUMMY-SLASHER-DOMAIN-SEPARATOR");
     }
 
-    function slash(
-        ISlasher.Delegation calldata delegation,
-        bytes calldata evidence
-    ) external returns (uint256 slashAmountGwei) {
+    function slash(ISlasher.Delegation calldata delegation, bytes calldata evidence)
+        external
+        returns (uint256 slashAmountGwei)
+    {
         slashAmountGwei = SLASH_AMOUNT_GWEI;
     }
 }
@@ -72,7 +72,9 @@ contract DummySlasherTest is UnitTestHelper {
         // slash from a different address
         vm.prank(bob);
         vm.expectEmit(address(registry));
-        emit IRegistry.OperatorSlashed(result.registrationRoot, slashAmountGwei, result.signedDelegation.delegation.validatorPubKey);
+        emit IRegistry.OperatorSlashed(
+            result.registrationRoot, slashAmountGwei, result.signedDelegation.delegation.validatorPubKey
+        );
         emit IRegistry.OperatorDeleted(result.registrationRoot);
         uint256 gotSlashAmountGwei = registry.slashCommitment(
             result.registrationRoot,
@@ -86,13 +88,7 @@ contract DummySlasherTest is UnitTestHelper {
 
         // verify balances updated correctly
         _verifySlashingBalances(
-            bob,
-            alice,
-            slashAmountGwei * 1 gwei,
-            collateral,
-            bobBalanceBefore,
-            aliceBalanceBefore,
-            urcBalanceBefore
+            bob, alice, slashAmountGwei * 1 gwei, collateral, bobBalanceBefore, aliceBalanceBefore, urcBalanceBefore
         );
 
         // Verify operator was deleted
@@ -156,12 +152,7 @@ contract DummySlasherTest is UnitTestHelper {
 
         vm.expectRevert(IRegistry.NotRegisteredValidator.selector);
         registry.slashCommitment(
-            result.registrationRoot,
-            result.registrations[0].signature,
-            invalidProof,
-            0,
-            result.signedDelegation,
-            ""
+            result.registrationRoot, result.registrations[0].signature, invalidProof, 0, result.signedDelegation, ""
         );
     }
 
@@ -182,11 +173,8 @@ contract DummySlasherTest is UnitTestHelper {
         RegisterAndDelegateResult memory result = registerAndDelegate(params);
 
         // Sign delegation with different secret key
-        ISlasher.SignedDelegation memory badSignedDelegation = signDelegation(
-            SECRET_KEY_2,
-            result.signedDelegation.delegation,
-            params.domainSeparator
-        );
+        ISlasher.SignedDelegation memory badSignedDelegation =
+            signDelegation(SECRET_KEY_2, result.signedDelegation.delegation, params.domainSeparator);
 
         bytes32[] memory leaves = _hashToLeaves(result.registrations);
         uint256 leafIndex = 0;

--- a/test/UnitTestHelper.sol
+++ b/test/UnitTestHelper.sol
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0 <0.9.0;
+
+import "forge-std/Test.sol";
+import "../src/Registry.sol";
+import "../src/IRegistry.sol";
+import { BLS } from "../src/lib/BLS.sol";
+
+contract UnitTestHelper is Test {
+    using BLS for *;
+
+    Registry registry;
+    address alice = makeAddr("alice");
+    address bob = makeAddr("bob");
+
+    // Preset secret keys for deterministic testing
+    uint256 constant SECRET_KEY_1 = 12345;
+    uint256 constant SECRET_KEY_2 = 67890;
+
+    /// @dev Helper to create a BLS signature for a registration
+    function _registrationSignature(uint256 secretKey, address withdrawalAddress, uint16 unregistrationDelay)
+        internal
+        view
+        returns (BLS.G2Point memory)
+    {
+        bytes memory message = abi.encodePacked(withdrawalAddress, unregistrationDelay);
+        return BLS.sign(message, secretKey, registry.DOMAIN_SEPARATOR());
+    }
+
+    /// @dev Creates a Registration struct with a real BLS keypair
+    function _createRegistration(uint256 secretKey, address withdrawalAddress, uint16 unregistrationDelay)
+        internal
+        view
+        returns (IRegistry.Registration memory)
+    {
+        BLS.G1Point memory pubkey = BLS.toPublicKey(secretKey);
+        BLS.G2Point memory signature = _registrationSignature(secretKey, withdrawalAddress, unregistrationDelay);
+
+        return IRegistry.Registration({ pubkey: pubkey, signature: signature });
+    }
+
+    /// @dev Helper to verify operator data matches expected values
+    function _assertRegistration(
+        bytes32 registrationRoot,
+        address expectedWithdrawalAddress,
+        uint56 expectedCollateral,
+        uint32 expectedRegisteredAt,
+        uint32 expectedUnregisteredAt,
+        uint16 expectedUnregistrationDelay
+    ) internal view {
+        (
+            address withdrawalAddress,
+            uint56 collateral,
+            uint32 registeredAt,
+            uint32 unregisteredAt,
+            uint16 unregistrationDelay
+        ) = registry.registrations(registrationRoot);
+
+        assertEq(withdrawalAddress, expectedWithdrawalAddress, "Wrong withdrawal address");
+        assertEq(collateral, expectedCollateral, "Wrong collateral amount");
+        assertEq(registeredAt, expectedRegisteredAt, "Wrong registration block");
+        assertEq(unregisteredAt, expectedUnregisteredAt, "Wrong unregistration block");
+        assertEq(unregistrationDelay, expectedUnregistrationDelay, "Wrong unregistration delay");
+    }
+
+    function _hashToLeaves(IRegistry.Registration[] memory registrations) internal pure returns (bytes32[] memory) {
+        bytes32[] memory leaves = new bytes32[](registrations.length);
+        for (uint256 i = 0; i < registrations.length; i++) {
+            leaves[i] = keccak256(abi.encode(registrations[i]));
+        }
+        return leaves;
+    }
+
+    // New helper functions
+    function _setupBasicRegistrationParams() internal view returns (uint16 unregistrationDelay, uint256 collateral) {
+        unregistrationDelay = uint16(registry.MIN_UNREGISTRATION_DELAY());
+        collateral = registry.MIN_COLLATERAL();
+    }
+
+    function _setupSingleRegistration(uint256 secretKey, address withdrawalAddr, uint16 unregistrationDelay)
+        internal
+        view
+        returns (IRegistry.Registration[] memory)
+    {
+        IRegistry.Registration[] memory registrations = new IRegistry.Registration[](1);
+        registrations[0] = _createRegistration(secretKey, withdrawalAddr, unregistrationDelay);
+        return registrations;
+    }
+
+    function _verifySlashingBalances(
+        address challenger,
+        address operator,
+        uint256 slashedAmount,
+        uint256 totalCollateral,
+        uint256 challengerBalanceBefore,
+        uint256 operatorBalanceBefore,
+        uint256 urcBalanceBefore
+    ) internal view {
+        assertEq(challenger.balance, challengerBalanceBefore + slashedAmount, "challenger didn't receive reward");
+        assertEq(
+            operator.balance,
+            operatorBalanceBefore + totalCollateral - slashedAmount,
+            "operator didn't receive remaining funds"
+        );
+        assertEq(address(registry).balance, urcBalanceBefore - totalCollateral, "urc balance incorrect");
+    }
+}

--- a/test/UnitTestHelper.sol
+++ b/test/UnitTestHelper.sol
@@ -5,7 +5,7 @@ import "forge-std/Test.sol";
 import "../src/Registry.sol";
 import "../src/IRegistry.sol";
 import "../src/ISlasher.sol";
-import {BLS} from "../src/lib/BLS.sol";
+import { BLS } from "../src/lib/BLS.sol";
 
 contract UnitTestHelper is Test {
     using BLS for *;
@@ -19,32 +19,25 @@ contract UnitTestHelper is Test {
     uint256 constant SECRET_KEY_2 = 67890;
 
     /// @dev Helper to create a BLS signature for a registration
-    function _registrationSignature(
-        uint256 secretKey,
-        address withdrawalAddress,
-        uint16 unregistrationDelay
-    ) internal view returns (BLS.G2Point memory) {
-        bytes memory message = abi.encodePacked(
-            withdrawalAddress,
-            unregistrationDelay
-        );
+    function _registrationSignature(uint256 secretKey, address withdrawalAddress, uint16 unregistrationDelay)
+        internal
+        view
+        returns (BLS.G2Point memory)
+    {
+        bytes memory message = abi.encodePacked(withdrawalAddress, unregistrationDelay);
         return BLS.sign(message, secretKey, registry.DOMAIN_SEPARATOR());
     }
 
     /// @dev Creates a Registration struct with a real BLS keypair
-    function _createRegistration(
-        uint256 secretKey,
-        address withdrawalAddress,
-        uint16 unregistrationDelay
-    ) internal view returns (IRegistry.Registration memory) {
+    function _createRegistration(uint256 secretKey, address withdrawalAddress, uint16 unregistrationDelay)
+        internal
+        view
+        returns (IRegistry.Registration memory)
+    {
         BLS.G1Point memory pubkey = BLS.toPublicKey(secretKey);
-        BLS.G2Point memory signature = _registrationSignature(
-            secretKey,
-            withdrawalAddress,
-            unregistrationDelay
-        );
+        BLS.G2Point memory signature = _registrationSignature(secretKey, withdrawalAddress, unregistrationDelay);
 
-        return IRegistry.Registration({pubkey: pubkey, signature: signature});
+        return IRegistry.Registration({ pubkey: pubkey, signature: signature });
     }
 
     /// @dev Helper to verify operator data matches expected values
@@ -64,32 +57,14 @@ contract UnitTestHelper is Test {
             uint16 unregistrationDelay
         ) = registry.registrations(registrationRoot);
 
-        assertEq(
-            withdrawalAddress,
-            expectedWithdrawalAddress,
-            "Wrong withdrawal address"
-        );
+        assertEq(withdrawalAddress, expectedWithdrawalAddress, "Wrong withdrawal address");
         assertEq(collateral, expectedCollateral, "Wrong collateral amount");
-        assertEq(
-            registeredAt,
-            expectedRegisteredAt,
-            "Wrong registration block"
-        );
-        assertEq(
-            unregisteredAt,
-            expectedUnregisteredAt,
-            "Wrong unregistration block"
-        );
-        assertEq(
-            unregistrationDelay,
-            expectedUnregistrationDelay,
-            "Wrong unregistration delay"
-        );
+        assertEq(registeredAt, expectedRegisteredAt, "Wrong registration block");
+        assertEq(unregisteredAt, expectedUnregisteredAt, "Wrong unregistration block");
+        assertEq(unregistrationDelay, expectedUnregistrationDelay, "Wrong unregistration delay");
     }
 
-    function _hashToLeaves(
-        IRegistry.Registration[] memory registrations
-    ) internal pure returns (bytes32[] memory) {
+    function _hashToLeaves(IRegistry.Registration[] memory registrations) internal pure returns (bytes32[] memory) {
         bytes32[] memory leaves = new bytes32[](registrations.length);
         for (uint256 i = 0; i < registrations.length; i++) {
             leaves[i] = keccak256(abi.encode(registrations[i]));
@@ -98,27 +73,18 @@ contract UnitTestHelper is Test {
     }
 
     // New helper functions
-    function _setupBasicRegistrationParams()
-        internal
-        view
-        returns (uint16 unregistrationDelay, uint256 collateral)
-    {
+    function _setupBasicRegistrationParams() internal view returns (uint16 unregistrationDelay, uint256 collateral) {
         unregistrationDelay = uint16(registry.MIN_UNREGISTRATION_DELAY());
         collateral = registry.MIN_COLLATERAL();
     }
 
-    function _setupSingleRegistration(
-        uint256 secretKey,
-        address withdrawalAddr,
-        uint16 unregistrationDelay
-    ) internal view returns (IRegistry.Registration[] memory) {
-        IRegistry.Registration[]
-            memory registrations = new IRegistry.Registration[](1);
-        registrations[0] = _createRegistration(
-            secretKey,
-            withdrawalAddr,
-            unregistrationDelay
-        );
+    function _setupSingleRegistration(uint256 secretKey, address withdrawalAddr, uint16 unregistrationDelay)
+        internal
+        view
+        returns (IRegistry.Registration[] memory)
+    {
+        IRegistry.Registration[] memory registrations = new IRegistry.Registration[](1);
+        registrations[0] = _createRegistration(secretKey, withdrawalAddr, unregistrationDelay);
         return registrations;
     }
 
@@ -131,47 +97,24 @@ contract UnitTestHelper is Test {
         uint256 operatorBalanceBefore,
         uint256 urcBalanceBefore
     ) internal view {
-        assertEq(
-            challenger.balance,
-            challengerBalanceBefore + slashedAmount,
-            "challenger didn't receive reward"
-        );
+        assertEq(challenger.balance, challengerBalanceBefore + slashedAmount, "challenger didn't receive reward");
         assertEq(
             operator.balance,
             operatorBalanceBefore + totalCollateral - slashedAmount,
             "operator didn't receive remaining funds"
         );
-        assertEq(
-            address(registry).balance,
-            urcBalanceBefore - totalCollateral,
-            "urc balance incorrect"
-        );
+        assertEq(address(registry).balance, urcBalanceBefore - totalCollateral, "urc balance incorrect");
     }
 
-    function basicRegistration(
-        uint256 secretKey,
-        uint256 collateral,
-        address withdrawalAddress
-    )
+    function basicRegistration(uint256 secretKey, uint256 collateral, address withdrawalAddress)
         public
-        returns (
-            bytes32 registrationRoot,
-            IRegistry.Registration[] memory registrations
-        )
+        returns (bytes32 registrationRoot, IRegistry.Registration[] memory registrations)
     {
-        (uint16 unregistrationDelay, ) = _setupBasicRegistrationParams();
+        (uint16 unregistrationDelay,) = _setupBasicRegistrationParams();
 
-        registrations = _setupSingleRegistration(
-            secretKey,
-            withdrawalAddress,
-            unregistrationDelay
-        );
+        registrations = _setupSingleRegistration(secretKey, withdrawalAddress, unregistrationDelay);
 
-        registrationRoot = registry.register{value: collateral}(
-            registrations,
-            withdrawalAddress,
-            unregistrationDelay
-        );
+        registrationRoot = registry.register{ value: collateral }(registrations, withdrawalAddress, unregistrationDelay);
 
         _assertRegistration(
             registrationRoot,
@@ -183,21 +126,13 @@ contract UnitTestHelper is Test {
         );
     }
 
-    function signDelegation(
-        uint256 secretKey,
-        ISlasher.Delegation memory delegation,
-        bytes memory domainSeparator
-    ) internal view returns (ISlasher.SignedDelegation memory) {
-        BLS.G2Point memory signature = BLS.sign(
-            abi.encode(delegation),
-            secretKey,
-            domainSeparator
-        );
-        return
-            ISlasher.SignedDelegation({
-                delegation: delegation,
-                signature: signature
-            });
+    function signDelegation(uint256 secretKey, ISlasher.Delegation memory delegation, bytes memory domainSeparator)
+        internal
+        view
+        returns (ISlasher.SignedDelegation memory)
+    {
+        BLS.G2Point memory signature = BLS.sign(abi.encode(delegation), secretKey, domainSeparator);
+        return ISlasher.SignedDelegation({ delegation: delegation, signature: signature });
     }
 
     struct RegisterAndDelegateParams {
@@ -216,9 +151,13 @@ contract UnitTestHelper is Test {
         ISlasher.SignedDelegation signedDelegation;
     }
 
-    function registerAndDelegate(RegisterAndDelegateParams memory params) public returns (RegisterAndDelegateResult memory result) {
+    function registerAndDelegate(RegisterAndDelegateParams memory params)
+        public
+        returns (RegisterAndDelegateResult memory result)
+    {
         // Single registration
-        (result.registrationRoot, result.registrations) = basicRegistration(params.validatorSecretKey, params.collateral, params.withdrawalAddress);
+        (result.registrationRoot, result.registrations) =
+            basicRegistration(params.validatorSecretKey, params.collateral, params.withdrawalAddress);
 
         // Sign delegation
         ISlasher.Delegation memory delegation = ISlasher.Delegation({

--- a/test/UnitTestHelper.sol
+++ b/test/UnitTestHelper.sol
@@ -4,7 +4,8 @@ pragma solidity >=0.8.0 <0.9.0;
 import "forge-std/Test.sol";
 import "../src/Registry.sol";
 import "../src/IRegistry.sol";
-import { BLS } from "../src/lib/BLS.sol";
+import "../src/ISlasher.sol";
+import {BLS} from "../src/lib/BLS.sol";
 
 contract UnitTestHelper is Test {
     using BLS for *;
@@ -18,25 +19,32 @@ contract UnitTestHelper is Test {
     uint256 constant SECRET_KEY_2 = 67890;
 
     /// @dev Helper to create a BLS signature for a registration
-    function _registrationSignature(uint256 secretKey, address withdrawalAddress, uint16 unregistrationDelay)
-        internal
-        view
-        returns (BLS.G2Point memory)
-    {
-        bytes memory message = abi.encodePacked(withdrawalAddress, unregistrationDelay);
+    function _registrationSignature(
+        uint256 secretKey,
+        address withdrawalAddress,
+        uint16 unregistrationDelay
+    ) internal view returns (BLS.G2Point memory) {
+        bytes memory message = abi.encodePacked(
+            withdrawalAddress,
+            unregistrationDelay
+        );
         return BLS.sign(message, secretKey, registry.DOMAIN_SEPARATOR());
     }
 
     /// @dev Creates a Registration struct with a real BLS keypair
-    function _createRegistration(uint256 secretKey, address withdrawalAddress, uint16 unregistrationDelay)
-        internal
-        view
-        returns (IRegistry.Registration memory)
-    {
+    function _createRegistration(
+        uint256 secretKey,
+        address withdrawalAddress,
+        uint16 unregistrationDelay
+    ) internal view returns (IRegistry.Registration memory) {
         BLS.G1Point memory pubkey = BLS.toPublicKey(secretKey);
-        BLS.G2Point memory signature = _registrationSignature(secretKey, withdrawalAddress, unregistrationDelay);
+        BLS.G2Point memory signature = _registrationSignature(
+            secretKey,
+            withdrawalAddress,
+            unregistrationDelay
+        );
 
-        return IRegistry.Registration({ pubkey: pubkey, signature: signature });
+        return IRegistry.Registration({pubkey: pubkey, signature: signature});
     }
 
     /// @dev Helper to verify operator data matches expected values
@@ -56,14 +64,32 @@ contract UnitTestHelper is Test {
             uint16 unregistrationDelay
         ) = registry.registrations(registrationRoot);
 
-        assertEq(withdrawalAddress, expectedWithdrawalAddress, "Wrong withdrawal address");
+        assertEq(
+            withdrawalAddress,
+            expectedWithdrawalAddress,
+            "Wrong withdrawal address"
+        );
         assertEq(collateral, expectedCollateral, "Wrong collateral amount");
-        assertEq(registeredAt, expectedRegisteredAt, "Wrong registration block");
-        assertEq(unregisteredAt, expectedUnregisteredAt, "Wrong unregistration block");
-        assertEq(unregistrationDelay, expectedUnregistrationDelay, "Wrong unregistration delay");
+        assertEq(
+            registeredAt,
+            expectedRegisteredAt,
+            "Wrong registration block"
+        );
+        assertEq(
+            unregisteredAt,
+            expectedUnregisteredAt,
+            "Wrong unregistration block"
+        );
+        assertEq(
+            unregistrationDelay,
+            expectedUnregistrationDelay,
+            "Wrong unregistration delay"
+        );
     }
 
-    function _hashToLeaves(IRegistry.Registration[] memory registrations) internal pure returns (bytes32[] memory) {
+    function _hashToLeaves(
+        IRegistry.Registration[] memory registrations
+    ) internal pure returns (bytes32[] memory) {
         bytes32[] memory leaves = new bytes32[](registrations.length);
         for (uint256 i = 0; i < registrations.length; i++) {
             leaves[i] = keccak256(abi.encode(registrations[i]));
@@ -72,18 +98,27 @@ contract UnitTestHelper is Test {
     }
 
     // New helper functions
-    function _setupBasicRegistrationParams() internal view returns (uint16 unregistrationDelay, uint256 collateral) {
+    function _setupBasicRegistrationParams()
+        internal
+        view
+        returns (uint16 unregistrationDelay, uint256 collateral)
+    {
         unregistrationDelay = uint16(registry.MIN_UNREGISTRATION_DELAY());
         collateral = registry.MIN_COLLATERAL();
     }
 
-    function _setupSingleRegistration(uint256 secretKey, address withdrawalAddr, uint16 unregistrationDelay)
-        internal
-        view
-        returns (IRegistry.Registration[] memory)
-    {
-        IRegistry.Registration[] memory registrations = new IRegistry.Registration[](1);
-        registrations[0] = _createRegistration(secretKey, withdrawalAddr, unregistrationDelay);
+    function _setupSingleRegistration(
+        uint256 secretKey,
+        address withdrawalAddr,
+        uint16 unregistrationDelay
+    ) internal view returns (IRegistry.Registration[] memory) {
+        IRegistry.Registration[]
+            memory registrations = new IRegistry.Registration[](1);
+        registrations[0] = _createRegistration(
+            secretKey,
+            withdrawalAddr,
+            unregistrationDelay
+        );
         return registrations;
     }
 
@@ -96,12 +131,103 @@ contract UnitTestHelper is Test {
         uint256 operatorBalanceBefore,
         uint256 urcBalanceBefore
     ) internal view {
-        assertEq(challenger.balance, challengerBalanceBefore + slashedAmount, "challenger didn't receive reward");
+        assertEq(
+            challenger.balance,
+            challengerBalanceBefore + slashedAmount,
+            "challenger didn't receive reward"
+        );
         assertEq(
             operator.balance,
             operatorBalanceBefore + totalCollateral - slashedAmount,
             "operator didn't receive remaining funds"
         );
-        assertEq(address(registry).balance, urcBalanceBefore - totalCollateral, "urc balance incorrect");
+        assertEq(
+            address(registry).balance,
+            urcBalanceBefore - totalCollateral,
+            "urc balance incorrect"
+        );
+    }
+
+    function basicRegistration(
+        uint256 secretKey,
+        uint256 collateral,
+        address withdrawalAddress
+    )
+        public
+        returns (
+            bytes32 registrationRoot,
+            IRegistry.Registration[] memory registrations
+        )
+    {
+        (uint16 unregistrationDelay, ) = _setupBasicRegistrationParams();
+
+        registrations = _setupSingleRegistration(
+            secretKey,
+            withdrawalAddress,
+            unregistrationDelay
+        );
+
+        registrationRoot = registry.register{value: collateral}(
+            registrations,
+            withdrawalAddress,
+            unregistrationDelay
+        );
+
+        _assertRegistration(
+            registrationRoot,
+            withdrawalAddress,
+            uint56(collateral / 1 gwei),
+            uint32(block.number),
+            0,
+            unregistrationDelay
+        );
+    }
+
+    function signDelegation(
+        uint256 secretKey,
+        ISlasher.Delegation memory delegation,
+        bytes memory domainSeparator
+    ) internal view returns (ISlasher.SignedDelegation memory) {
+        BLS.G2Point memory signature = BLS.sign(
+            abi.encode(delegation),
+            secretKey,
+            domainSeparator
+        );
+        return
+            ISlasher.SignedDelegation({
+                delegation: delegation,
+                signature: signature
+            });
+    }
+
+    struct RegisterAndDelegateParams {
+        uint256 validatorSecretKey;
+        uint256 collateral;
+        address withdrawalAddress;
+        uint256 delegateSecretKey;
+        address slasher;
+        bytes domainSeparator;
+        bytes metadata;
+    }
+
+    struct RegisterAndDelegateResult {
+        bytes32 registrationRoot;
+        IRegistry.Registration[] registrations;
+        ISlasher.SignedDelegation signedDelegation;
+    }
+
+    function registerAndDelegate(RegisterAndDelegateParams memory params) public returns (RegisterAndDelegateResult memory result) {
+        // Single registration
+        (result.registrationRoot, result.registrations) = basicRegistration(params.validatorSecretKey, params.collateral, params.withdrawalAddress);
+
+        // Sign delegation
+        ISlasher.Delegation memory delegation = ISlasher.Delegation({
+            validatorPubKey: BLS.toPublicKey(params.validatorSecretKey),
+            delegatePubKey: BLS.toPublicKey(params.delegateSecretKey),
+            slasher: params.slasher,
+            metadata: params.metadata
+        });
+
+        result.signedDelegation = signDelegation(params.validatorSecretKey, delegation, params.domainSeparator);
     }
 }


### PR DESCRIPTION
Added logic to Registry.sol to allow an operator to be slashed via the `slashCommitment()` function. 

- Resolves #13 
- Made modifications to the `DOMAIN_SEPERATOR` as described in #6 