### PR TITLE
Reentrancy Tests

### DIFF
--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -40,8 +40,6 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly
 
       - name: Show Forge version
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ out/
 /broadcast/**/dry-run/
 
 .env
+.cursorrules

--- a/test/Registry.t.sol
+++ b/test/Registry.t.sol
@@ -5,7 +5,9 @@ import "forge-std/Test.sol";
 import "../src/Registry.sol";
 import "../src/IRegistry.sol";
 import { BLS } from "../src/lib/BLS.sol";
-import { UnitTestHelper, ReentrantRegistrationContract } from "./UnitTestHelper.sol";
+import {
+    UnitTestHelper, ReentrantRegistrationContract, ReentrantSlashableRegistrationContract
+} from "./UnitTestHelper.sol";
 
 contract RegistryTest is UnitTestHelper {
     using BLS for *;
@@ -455,8 +457,8 @@ contract RegistryTest is UnitTestHelper {
             // Re-register to reset the state
             registrationRoot = registry.register{ value: collateral }(
                 registrations,
-                alice,
-                unregistrationDelay + 1 // submit different delay than the one signed by validator keys
+                bob, // submit different withdrawal address than the one signed by validator keys
+                unregistrationDelay
             );
 
             // update balances
@@ -636,6 +638,10 @@ contract RegistryTest is UnitTestHelper {
         registry.addCollateral{ value: 1 gwei }(registrationRoot);
     }
 
+    // For setup we register() -> unregister() -> claimCollateral()
+    // The registration's withdrawal address is the reentrant contract
+    // Claiming collateral causes the reentrant contract to reenter the registry and call: addCollateral(), unregister(), claimCollateral()
+    // The test succeeds because the reentract contract catches the errors
     function test_reentrantClaimCollateral() public {
         ReentrantRegistrationContract reentrantContract = new ReentrantRegistrationContract(address(registry));
         vm.deal(address(reentrantContract), 1000 ether);
@@ -666,5 +672,50 @@ contract RegistryTest is UnitTestHelper {
         // Verify registration was deleted
         (address withdrawalAddress,,,,) = registry.registrations(reentrantContract.registrationRoot());
         assertEq(withdrawalAddress, address(0), "Registration not deleted");
+    }
+
+    // For setup we register() -> slashRegistration()
+    // The registration's withdrawal address is the reentrant contract
+    // Triggering a slash causes the reentrant contract to reenter the registry and call: addCollateral(), unregister(), claimCollateral(), slashRegistration()
+    // Finally it re-registers and the registration root should not change
+    // The test succeeds because the reentract contract catches the errors
+    function test_reentrantSlashRegistration() public {
+        ReentrantSlashableRegistrationContract reentrantContract =
+            new ReentrantSlashableRegistrationContract(address(registry));
+        vm.deal(address(reentrantContract), 1000 ether);
+
+        (uint16 unregistrationDelay,) = _setupBasicRegistrationParams();
+        IRegistry.Registration[] memory registrations = new IRegistry.Registration[](1);
+
+        registrations[0] = _createRegistration(SECRET_KEY_1, bob, unregistrationDelay);
+
+        // set operator's withdrawal address to reentrantContract
+        reentrantContract.register(registrations, unregistrationDelay);
+
+        _assertRegistration(
+            reentrantContract.registrationRoot(),
+            address(reentrantContract),
+            uint56(1 ether / 1 gwei),
+            uint32(block.number),
+            type(uint32).max,
+            unregistrationDelay
+        );
+
+        // generate merkle proof
+        bytes32[] memory leaves = _hashToLeaves(registrations);
+        bytes32[] memory proof = MerkleTree.generateProof(leaves, 0);
+
+        uint256 bobBalanceBefore = bob.balance;
+        uint256 aliceBalanceBefore = alice.balance;
+        uint256 urcBalanceBefore = address(registry).balance;
+
+        // bob can slash the registration
+        vm.startPrank(bob);
+        uint256 slashedCollateralWei = registry.slashRegistration(
+            reentrantContract.registrationRoot(),
+            registrations[0],
+            proof,
+            0 // leafIndex
+        );
     }
 }

--- a/test/Slasher.t.sol
+++ b/test/Slasher.t.sol
@@ -315,7 +315,7 @@ contract DummySlasherTest is UnitTestHelper {
             domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
             metadata: "",
             validUntil: uint64(block.timestamp - 1) // Delegation expired
-        });
+         });
 
         RegisterAndDelegateResult memory result = registerAndDelegate(params);
 

--- a/test/UnitTestHelper.sol
+++ b/test/UnitTestHelper.sol
@@ -127,7 +127,7 @@ contract UnitTestHelper is Test {
     }
 
     function signDelegation(uint256 secretKey, ISlasher.Delegation memory delegation, bytes memory domainSeparator)
-        internal
+        public
         view
         returns (ISlasher.SignedDelegation memory)
     {
@@ -170,5 +170,152 @@ contract UnitTestHelper is Test {
         });
 
         result.signedDelegation = signDelegation(params.proposerSecretKey, delegation, params.domainSeparator);
+    }
+
+    function registerAndDelegateReentrant(RegisterAndDelegateParams memory params)
+        public
+        returns (RegisterAndDelegateResult memory result, address reentrantContractAddress)
+    {
+        ReentrantContract reentrantContract = new ReentrantContract(address(registry));
+
+        (uint16 unregistrationDelay,) = _setupBasicRegistrationParams();
+        result.registrations = _setupSingleRegistration(SECRET_KEY_1, address(reentrantContract), unregistrationDelay);
+
+        // register via reentrant contract
+        vm.deal(address(reentrantContract), 100 ether);
+        reentrantContract.register(result.registrations, unregistrationDelay);
+        result.registrationRoot = reentrantContract.registrationRoot();
+        reentrantContractAddress = address(reentrantContract);
+
+        // Sign delegation
+        ISlasher.Delegation memory delegation = ISlasher.Delegation({
+            proposerPubKey: BLS.toPublicKey(params.proposerSecretKey),
+            delegatePubKey: BLS.toPublicKey(params.delegateSecretKey),
+            slasher: params.slasher,
+            validUntil: params.validUntil,
+            metadata: params.metadata
+        });
+
+        result.signedDelegation = signDelegation(params.proposerSecretKey, delegation, params.domainSeparator);
+
+        // save info for later reentrancy
+        reentrantContract.saveResult(params, result);
+    }
+}
+
+/// @dev A contract that attempts to register, unregister, and claim collateral via reentrancy
+contract ReentrantContract {
+    IRegistry public registry;
+    bytes32 public registrationRoot;
+    uint256 public errors;
+    UnitTestHelper.RegisterAndDelegateParams params;
+    ISlasher.SignedDelegation signedDelegation;
+    IRegistry.Registration[1] registrations;
+
+    constructor(address registryAddress) {
+        registry = IRegistry(registryAddress);
+    }
+
+    function saveResult(
+        UnitTestHelper.RegisterAndDelegateParams memory _params,
+        UnitTestHelper.RegisterAndDelegateResult memory _result
+    ) public {
+        params = _params;
+        signedDelegation = _result.signedDelegation;
+        for (uint256 i = 0; i < _result.registrations.length; i++) {
+            registrations[i] = _result.registrations[i];
+        }
+    }
+
+    function _hashToLeaves(IRegistry.Registration[] memory registrations) internal pure returns (bytes32[] memory) {
+        bytes32[] memory leaves = new bytes32[](registrations.length);
+        for (uint256 i = 0; i < registrations.length; i++) {
+            leaves[i] = keccak256(abi.encode(registrations[i]));
+        }
+        return leaves;
+    }
+
+    function register(IRegistry.Registration[] memory _registrations, uint16 _unregistrationDelay) public {
+        registrationRoot = registry.register{ value: 1 ether }(_registrations, address(this), _unregistrationDelay);
+    }
+
+    function unregister() public {
+        registry.unregister(registrationRoot);
+    }
+
+    function claimCollateral() public {
+        registry.claimCollateral(registrationRoot);
+    }
+}
+
+/// @dev A contract that attempts to register, unregister, and claim collateral via reentrancy
+contract ReentrantRegistrationContract is ReentrantContract {
+    constructor(address registryAddress) ReentrantContract(registryAddress) { }
+
+    receive() external payable {
+        try registry.addCollateral{ value: msg.value }(registrationRoot) {
+            revert("should not be able to add collateral");
+        } catch (bytes memory _reason) {
+            errors += 1;
+        }
+
+        try registry.unregister(registrationRoot) {
+            revert("should not be able to unregister");
+        } catch (bytes memory _reason) {
+            errors += 1;
+        }
+
+        try registry.claimCollateral(registrationRoot) {
+            revert("should not be able to claim collateral");
+        } catch (bytes memory _reason) {
+            errors += 1;
+        }
+
+        require(errors == 3, "should have 3 errors");
+    }
+}
+
+/// @dev A contract that attempts to register, unregister, and claim collateral via reentrancy
+contract ReentrantSlashCommitment is ReentrantContract {
+    constructor(address registryAddress) ReentrantContract(registryAddress) { }
+
+    receive() external payable {
+        try registry.addCollateral{ value: msg.value }(registrationRoot) {
+            revert("should not be able to add collateral");
+        } catch (bytes memory _reason) {
+            errors += 1;
+        }
+
+        try registry.unregister(registrationRoot) {
+            revert("should not be able to unregister");
+        } catch (bytes memory _reason) {
+            errors += 1;
+        }
+
+        try registry.claimCollateral(registrationRoot) {
+            revert("should not be able to claim collateral");
+        } catch (bytes memory _reason) {
+            errors += 1;
+        }
+
+        revert("here");
+
+        // Setup proof
+        IRegistry.Registration[] memory _registrations;
+        _registrations[0] = registrations[0];
+        bytes32[] memory leaves = _hashToLeaves(_registrations);
+        uint256 leafIndex = 0;
+        bytes32[] memory proof = MerkleTree.generateProof(leaves, leafIndex);
+        bytes memory evidence = "";
+
+        try registry.slashCommitment(
+            registrationRoot, signedDelegation.signature, proof, leafIndex, signedDelegation, evidence
+        ) {
+            revert("should not be able to slash commitment again");
+        } catch (bytes memory _reason) {
+            errors += 1;
+        }
+
+        require(errors == 4, "should have 4 errors");
     }
 }


### PR DESCRIPTION
Add tests to attempt reentrancy for the cases where ETH is transferred to an external contract:
- claimCollateral()
- slashRegistration()
- slashCommitment()