### PR TITLE
Issue 22

### DIFF
--- a/example/ExclusionPreconfSlasher.sol
+++ b/example/ExclusionPreconfSlasher.sol
@@ -23,6 +23,7 @@ contract ExclusionPreconfSlasher is ISlasher {
     using EnumerableSet for EnumerableSet.Bytes32Set;
 
     uint256 public SLASH_AMOUNT_GWEI;
+    uint256 public REWARD_AMOUNT_GWEI;
     address public constant BEACON_ROOTS_CONTRACT =
         0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02;
     uint256 public constant EIP4788_WINDOW = 8191;
@@ -41,8 +42,9 @@ contract ExclusionPreconfSlasher is ISlasher {
     error InvalidBlockHash();
     error BeaconRootNotFound();
 
-    constructor(uint256 _slashAmountGwei) {
+    constructor(uint256 _slashAmountGwei, uint256 _rewardAmountGwei) {
         SLASH_AMOUNT_GWEI = _slashAmountGwei;
+        REWARD_AMOUNT_GWEI = _rewardAmountGwei;
 
         if (block.chainid == 17000) {
             // Holesky
@@ -59,7 +61,7 @@ contract ExclusionPreconfSlasher is ISlasher {
     function slash(
         ISlasher.Delegation calldata delegation,
         bytes calldata evidence
-    ) external returns (uint256 slashAmountGwei) {
+    ) external returns (uint256 slashAmountGwei, uint256 rewardAmountGwei) {
         // Operator delegated to an ECDSA signer as part of the metadata field
         address commitmentSigner = abi.decode(delegation.metadata, (address));
 
@@ -79,6 +81,7 @@ contract ExclusionPreconfSlasher is ISlasher {
 
         // Return the slash amount to the URC slasher
         slashAmountGwei = SLASH_AMOUNT_GWEI;
+        rewardAmountGwei = REWARD_AMOUNT_GWEI;
     }
 
     function DOMAIN_SEPARATOR() external view returns (bytes memory) {

--- a/src/IRegistry.sol
+++ b/src/IRegistry.sol
@@ -66,8 +66,9 @@ interface IRegistry {
     /// @notice Emitted when an operator is slashed for breaking a commitment
     /// @param registrationRoot The merkle root of the registration merkle tree
     /// @param slashAmountGwei The amount of GWEI slashed
+    /// @param rewardAmountGwei The amount of GWEI rewarded to the caller
     /// @param pubkey The BLS public key
-    event OperatorSlashed(bytes32 registrationRoot, uint256 slashAmountGwei, BLS.G1Point pubkey);
+    event OperatorSlashed(bytes32 registrationRoot, uint256 slashAmountGwei, uint256 rewardAmountGwei, BLS.G1Point pubkey);
 
     /// @notice Emitted when an operator is unregistered
     /// @param registrationRoot The merkle root of the registration merkle tree
@@ -150,5 +151,5 @@ interface IRegistry {
         uint256 leafIndex,
         ISlasher.SignedDelegation calldata signedDelegation,
         bytes calldata evidence
-    ) external returns (uint256 slashAmountGwei);
+    ) external returns (uint256 slashAmountGwei, uint256 rewardAmountGwei);
 }

--- a/src/IRegistry.sol
+++ b/src/IRegistry.sol
@@ -68,7 +68,9 @@ interface IRegistry {
     /// @param slashAmountGwei The amount of GWEI slashed
     /// @param rewardAmountGwei The amount of GWEI rewarded to the caller
     /// @param pubkey The BLS public key
-    event OperatorSlashed(bytes32 registrationRoot, uint256 slashAmountGwei, uint256 rewardAmountGwei, BLS.G1Point pubkey);
+    event OperatorSlashed(
+        bytes32 registrationRoot, uint256 slashAmountGwei, uint256 rewardAmountGwei, BLS.G1Point pubkey
+    );
 
     /// @notice Emitted when an operator is unregistered
     /// @param registrationRoot The merkle root of the registration merkle tree

--- a/src/ISlasher.sol
+++ b/src/ISlasher.sol
@@ -31,9 +31,10 @@ interface ISlasher {
     /// @param delegation The delegation message
     /// @param evidence Arbitrary evidence for the slashing
     /// @return slashAmountGwei The amount of Gwei slashed
+    /// @return rewardAmountGwei The amount of Gwei rewarded to the caller
     function slash(Delegation calldata delegation, bytes calldata evidence)
         external
-        returns (uint256 slashAmountGwei);
+        returns (uint256 slashAmountGwei, uint256 rewardAmountGwei);
 
     /// @notice The domain separator for the Slasher contract
     /// @dev The domain separator is used to prevent replay attacks from different Slasher contracts

--- a/src/Registry.sol
+++ b/src/Registry.sol
@@ -254,7 +254,9 @@ contract Registry is IRegistry {
         // Reward, burn, and return Ether
         _executeSlashingTransfers(operatorWithdrawalAddress, collateralGwei, slashAmountGwei, rewardAmountGwei);
 
-        emit OperatorSlashed(registrationRoot, slashAmountGwei, rewardAmountGwei, signedDelegation.delegation.proposerPubKey);
+        emit OperatorSlashed(
+            registrationRoot, slashAmountGwei, rewardAmountGwei, signedDelegation.delegation.proposerPubKey
+        );
     }
 
     /// @notice Adds collateral to an Operator struct
@@ -369,10 +371,8 @@ contract Registry is IRegistry {
         bytes calldata evidence,
         uint256 collateralGwei
     ) internal returns (uint256 slashAmountGwei, uint256 rewardAmountGwei) {
-        (slashAmountGwei, rewardAmountGwei) = ISlasher(signedDelegation.delegation.slasher).slash(
-            signedDelegation.delegation,
-            evidence
-        );
+        (slashAmountGwei, rewardAmountGwei) =
+            ISlasher(signedDelegation.delegation.slasher).slash(signedDelegation.delegation, evidence);
 
         if (slashAmountGwei > collateralGwei) {
             revert SlashAmountExceedsCollateral();
@@ -385,9 +385,12 @@ contract Registry is IRegistry {
     /// @param collateralGwei The operator's collateral amount in GWEI
     /// @param slashAmountGwei The amount of GWEI to be transferred to the caller
     /// @param rewardAmountGwei The amount of GWEI to be transferred to the caller
-    function _executeSlashingTransfers(address withdrawalAddress, uint256 collateralGwei, uint256 slashAmountGwei, uint256 rewardAmountGwei)
-        internal
-    {
+    function _executeSlashingTransfers(
+        address withdrawalAddress,
+        uint256 collateralGwei,
+        uint256 slashAmountGwei,
+        uint256 rewardAmountGwei
+    ) internal {
         // Burn the slash amount
         (bool success,) = BURNER_ADDRESS.call{ value: slashAmountGwei * 1 gwei }("");
         if (!success) {

--- a/src/Registry.sol
+++ b/src/Registry.sol
@@ -130,11 +130,10 @@ contract Registry is IRegistry {
         delete registrations[registrationRoot];
 
         // Calculate the amount to transfer to challenger and return to operator
-        slashedCollateralWei = MIN_COLLATERAL;
-        uint256 remainingWei = uint256(collateralGwei) * 1 gwei - slashedCollateralWei;
+        uint256 remainingWei = uint256(collateralGwei) * 1 gwei - MIN_COLLATERAL;
 
         // Transfer to the challenger
-        (bool success,) = msg.sender.call{ value: slashedCollateralWei }("");
+        (bool success,) = msg.sender.call{ value: MIN_COLLATERAL }("");
         if (!success) {
             revert EthTransferFailed();
         }
@@ -146,6 +145,8 @@ contract Registry is IRegistry {
         }
 
         emit RegistrationSlashed(registrationRoot, msg.sender, operatorWithdrawalAddress, reg);
+
+        return MIN_COLLATERAL;
     }
 
     /// @notice Starts the unregistration process for an operator

--- a/test/ExclusionPreconfSlasher.t.sol
+++ b/test/ExclusionPreconfSlasher.t.sol
@@ -31,7 +31,7 @@ contract ExclusionPreconfSlasherTest is UnitTestHelper {
     BLS.G1Point delegatePubKey;
     uint256 slashAmountGwei = 1 ether / 1 gwei; // slash 1 ether
     uint256 rewardAmountGwei = 0.1 ether / 1 gwei; // reward 0.1 ether
-    uint256 collateral = 1 ether;
+    uint256 collateral = 1.1 ether;
 
     function setUp() public {
         vm.createSelectFork(vm.rpcUrl("mainnet"));

--- a/test/ExclusionPreconfSlasher.t.sol
+++ b/test/ExclusionPreconfSlasher.t.sol
@@ -200,7 +200,14 @@ contract ExclusionPreconfSlasherTest is UnitTestHelper {
 
         // verify balances updated correctly
         _verifySlashingBalances(
-            bob, alice, slashAmountGwei * 1 gwei, rewardAmountGwei * 1 gwei, collateral, bobBalanceBefore, aliceBalanceBefore, urcBalanceBefore
+            bob,
+            alice,
+            slashAmountGwei * 1 gwei,
+            rewardAmountGwei * 1 gwei,
+            collateral,
+            bobBalanceBefore,
+            aliceBalanceBefore,
+            urcBalanceBefore
         );
 
         // Verify operator was deleted

--- a/test/ExclusionPreconfSlasher.t.sol
+++ b/test/ExclusionPreconfSlasher.t.sol
@@ -200,7 +200,7 @@ contract ExclusionPreconfSlasherTest is UnitTestHelper {
 
         // verify balances updated correctly
         _verifySlashingBalances(
-            bob, alice, slashAmountGwei * 1 gwei, collateral, bobBalanceBefore, aliceBalanceBefore, urcBalanceBefore
+            bob, alice, slashAmountGwei * 1 gwei, rewardAmountGwei * 1 gwei, collateral, bobBalanceBefore, aliceBalanceBefore, urcBalanceBefore
         );
 
         // Verify operator was deleted

--- a/test/ExclusionPreconfSlasher.t.sol
+++ b/test/ExclusionPreconfSlasher.t.sol
@@ -30,11 +30,12 @@ contract ExclusionPreconfSlasherTest is UnitTestHelper {
     ExclusionPreconfSlasher slasher;
     BLS.G1Point delegatePubKey;
     uint256 slashAmountGwei = 1 ether / 1 gwei; // slash 1 ether
+    uint256 rewardAmountGwei = 0.1 ether / 1 gwei; // reward 0.1 ether
     uint256 collateral = 1 ether;
 
     function setUp() public {
         vm.createSelectFork(vm.rpcUrl("mainnet"));
-        slasher = new ExclusionPreconfSlasher(slashAmountGwei);
+        slasher = new ExclusionPreconfSlasher(slashAmountGwei, rewardAmountGwei);
         registry = new Registry();
         delegatePubKey = BLS.toPublicKey(SECRET_KEY_2);
     }

--- a/test/Registry.t.sol
+++ b/test/Registry.t.sol
@@ -144,7 +144,7 @@ contract RegistryTest is UnitTestHelper {
         assertEq(slashedCollateralWei, collateral, "Wrong slashedCollateralWei amount");
 
         _verifySlashingBalances(
-            bob, alice, slashedCollateralWei, collateral, bobBalanceBefore, aliceBalanceBefore, urcBalanceBefore
+            bob, alice, slashedCollateralWei, 0, collateral, bobBalanceBefore, aliceBalanceBefore, urcBalanceBefore
         );
 
         _assertRegistration(registrationRoot, address(0), 0, 0, 0, 0);
@@ -194,7 +194,7 @@ contract RegistryTest is UnitTestHelper {
         );
 
         _verifySlashingBalances(
-            alice, bob, slashedCollateralWei, collateral, bobBalanceBefore, aliceBalanceBefore, urcBalanceBefore
+            alice, bob, slashedCollateralWei, 0, collateral, bobBalanceBefore, aliceBalanceBefore, urcBalanceBefore
         );
 
         // ensure operator was deleted
@@ -275,7 +275,7 @@ contract RegistryTest is UnitTestHelper {
         uint256 slashedCollateralWei = registry.slashRegistration(registrationRoot, registrations[0], proof, leafIndex);
 
         _verifySlashingBalances(
-            bob, alice, slashedCollateralWei, collateral, bobBalanceBefore, aliceBalanceBefore, urcBalanceBefore
+            bob, alice, slashedCollateralWei, 0, collateral, bobBalanceBefore, aliceBalanceBefore, urcBalanceBefore
         );
     }
 
@@ -316,7 +316,7 @@ contract RegistryTest is UnitTestHelper {
         uint256 slashedCollateralWei = registry.slashRegistration(registrationRoot, registrations[0], proof, leafIndex);
 
         _verifySlashingBalances(
-            alice, bob, slashedCollateralWei, collateral, bobBalanceBefore, aliceBalanceBefore, urcBalanceBefore
+            alice, bob, slashedCollateralWei, 0, collateral, bobBalanceBefore, aliceBalanceBefore, urcBalanceBefore
         );
     }
 
@@ -402,7 +402,7 @@ contract RegistryTest is UnitTestHelper {
             vm.prank(bob);
             uint256 slashedCollateralWei = registry.slashRegistration(registrationRoot, registrations[i], proof, i);
             _verifySlashingBalances(
-                bob, alice, slashedCollateralWei, collateral, bobBalanceBefore, aliceBalanceBefore, urcBalanceBefore
+                bob, alice, slashedCollateralWei, 0, collateral, bobBalanceBefore, aliceBalanceBefore, urcBalanceBefore
             );
 
             _assertRegistration(registrationRoot, address(0), 0, 0, 0, 0);
@@ -449,7 +449,7 @@ contract RegistryTest is UnitTestHelper {
             vm.prank(bob);
             uint256 slashedCollateralWei = registry.slashRegistration(registrationRoot, registrations[i], proof, i);
             _verifySlashingBalances(
-                bob, alice, slashedCollateralWei, collateral, bobBalanceBefore, aliceBalanceBefore, urcBalanceBefore
+                bob, alice, slashedCollateralWei, 0, collateral, bobBalanceBefore, aliceBalanceBefore, urcBalanceBefore
             );
 
             _assertRegistration(registrationRoot, address(0), 0, 0, 0, 0);

--- a/test/Registry.t.sol
+++ b/test/Registry.t.sol
@@ -24,18 +24,18 @@ contract RegistryTest is UnitTestHelper {
     }
 
     function test_register_insufficientCollateral() public {
-        (uint16 unregistrationDelay, uint256 collateral) = _setupBasicRegistrationParams();
+        (uint16 unregistrationDelay, uint256 minCollateral) = _setupBasicRegistrationParams();
 
         IRegistry.Registration[] memory registrations = new IRegistry.Registration[](1);
 
         registrations[0] = _createRegistration(SECRET_KEY_1, alice, unregistrationDelay);
 
         vm.expectRevert(IRegistry.InsufficientCollateral.selector);
-        registry.register{ value: collateral - 1 }(registrations, alice, unregistrationDelay);
+        registry.register{ value: minCollateral - 1 }(registrations, alice, unregistrationDelay);
     }
 
     function test_register_unregistrationDelayTooShort() public {
-        (uint16 unregistrationDelay, uint256 collateral) = _setupBasicRegistrationParams();
+        (uint16 unregistrationDelay, uint256 minCollateral) = _setupBasicRegistrationParams();
 
         IRegistry.Registration[] memory registrations = new IRegistry.Registration[](1);
 
@@ -46,7 +46,7 @@ contract RegistryTest is UnitTestHelper {
         );
 
         vm.expectRevert(IRegistry.UnregistrationDelayTooShort.selector);
-        registry.register{ value: collateral }(
+        registry.register{ value: minCollateral }(
             registrations,
             alice,
             unregistrationDelay - 1 // submit shorter delay than the one signed by validator key
@@ -54,18 +54,22 @@ contract RegistryTest is UnitTestHelper {
     }
 
     function test_register_OperatorAlreadyRegistered() public {
-        (uint16 unregistrationDelay, uint256 collateral) = _setupBasicRegistrationParams();
+        (uint16 unregistrationDelay, uint256 minCollateral) = _setupBasicRegistrationParams();
 
         IRegistry.Registration[] memory registrations = new IRegistry.Registration[](1);
 
         registrations[0] = _createRegistration(SECRET_KEY_1, alice, unregistrationDelay);
 
-        bytes32 registrationRoot = registry.register{ value: collateral }(registrations, alice, unregistrationDelay);
+        bytes32 registrationRoot = registry.register{ value: minCollateral }(
+            registrations,
+            alice,
+            unregistrationDelay
+        );
 
         _assertRegistration(
             registrationRoot,
             alice,
-            uint56(collateral / 1 gwei),
+            uint56(minCollateral / 1 gwei),
             uint32(block.number),
             type(uint32).max,
             unregistrationDelay
@@ -73,22 +77,26 @@ contract RegistryTest is UnitTestHelper {
 
         // Attempt duplicate registration
         vm.expectRevert(IRegistry.OperatorAlreadyRegistered.selector);
-        registry.register{ value: collateral }(registrations, alice, unregistrationDelay);
+        registry.register{ value: minCollateral }(registrations, alice, unregistrationDelay);
     }
 
     function test_verifyMerkleProofHeight1() public {
-        (uint16 unregistrationDelay, uint256 collateral) = _setupBasicRegistrationParams();
+        (uint16 unregistrationDelay, uint256 minCollateral) = _setupBasicRegistrationParams();
 
         IRegistry.Registration[] memory registrations = new IRegistry.Registration[](1);
 
         registrations[0] = _createRegistration(SECRET_KEY_1, alice, unregistrationDelay);
 
-        bytes32 registrationRoot = registry.register{ value: collateral }(registrations, alice, unregistrationDelay);
+        bytes32 registrationRoot = registry.register{ value: minCollateral }(
+            registrations,
+            alice,
+            unregistrationDelay
+        );
 
         _assertRegistration(
             registrationRoot,
             alice,
-            uint56(collateral / 1 gwei),
+            uint56(minCollateral / 1 gwei),
             uint32(block.number),
             type(uint32).max,
             unregistrationDelay
@@ -104,11 +112,12 @@ contract RegistryTest is UnitTestHelper {
             proof,
             0 // leafIndex
         );
-        assertEq(gotCollateral, uint56(collateral / 1 gwei), "Wrong collateral amount");
+        assertEq(gotCollateral, uint56(minCollateral / 1 gwei), "Wrong collateral amount");
     }
 
     function test_slashRegistrationHeight1_DifferentUnregDelay() public {
-        (uint16 unregistrationDelay, uint256 collateral) = _setupBasicRegistrationParams();
+        (uint16 unregistrationDelay, uint256 minCollateral) = _setupBasicRegistrationParams();
+        uint256 collateral = 2 * minCollateral;
 
         IRegistry.Registration[] memory registrations = _setupSingleRegistration(
             SECRET_KEY_1,
@@ -140,18 +149,19 @@ contract RegistryTest is UnitTestHelper {
         uint256 urcBalanceBefore = address(registry).balance;
 
         vm.prank(bob);
-        uint256 slashedCollateralWei = registry.slashRegistration(registrationRoot, registrations[0], proof, 0);
-        assertEq(slashedCollateralWei, collateral, "Wrong slashedCollateralWei amount");
+        uint256 rewardCollateralWei = registry.slashRegistration(registrationRoot, registrations[0], proof, 0);
+        assertEq(rewardCollateralWei, minCollateral, "Wrong rewardCollateralWei amount");
 
         _verifySlashingBalances(
-            bob, alice, slashedCollateralWei, 0, collateral, bobBalanceBefore, aliceBalanceBefore, urcBalanceBefore
+            bob, alice, 0, rewardCollateralWei, collateral, bobBalanceBefore, aliceBalanceBefore, urcBalanceBefore
         );
 
         _assertRegistration(registrationRoot, address(0), 0, 0, 0, 0);
     }
 
     function test_slashRegistrationHeight1_DifferentWithdrawalAddress() public {
-        (uint16 unregistrationDelay, uint256 collateral) = _setupBasicRegistrationParams();
+        (uint16 unregistrationDelay, uint256 minCollateral) = _setupBasicRegistrationParams();
+        uint256 collateral = 2 * minCollateral;
 
         IRegistry.Registration[] memory registrations = new IRegistry.Registration[](1);
 
@@ -186,7 +196,7 @@ contract RegistryTest is UnitTestHelper {
 
         // alice is the challenger
         vm.prank(alice);
-        uint256 slashedCollateralWei = registry.slashRegistration(
+        uint256 rewardCollateralWei = registry.slashRegistration(
             registrationRoot,
             registrations[0],
             proof,
@@ -194,7 +204,7 @@ contract RegistryTest is UnitTestHelper {
         );
 
         _verifySlashingBalances(
-            alice, bob, slashedCollateralWei, 0, collateral, bobBalanceBefore, aliceBalanceBefore, urcBalanceBefore
+            alice, bob, 0, rewardCollateralWei, collateral, bobBalanceBefore, aliceBalanceBefore, urcBalanceBefore
         );
 
         // ensure operator was deleted
@@ -202,7 +212,8 @@ contract RegistryTest is UnitTestHelper {
     }
 
     function test_verifyMerkleProofHeight2() public {
-        (uint16 unregistrationDelay, uint256 collateral) = _setupBasicRegistrationParams();
+        (uint16 unregistrationDelay, uint256 minCollateral) = _setupBasicRegistrationParams();
+        uint256 collateral = 2 * minCollateral;
 
         IRegistry.Registration[] memory registrations = new IRegistry.Registration[](2);
 
@@ -237,7 +248,8 @@ contract RegistryTest is UnitTestHelper {
     }
 
     function test_slashRegistrationHeight2_DifferentUnregDelay() public {
-        (uint16 unregistrationDelay, uint256 collateral) = _setupBasicRegistrationParams();
+        (uint16 unregistrationDelay, uint256 minCollateral) = _setupBasicRegistrationParams();
+        uint256 collateral = 2 * minCollateral;
 
         IRegistry.Registration[] memory registrations = new IRegistry.Registration[](2);
         registrations[0] = _createRegistration(SECRET_KEY_1, alice, unregistrationDelay);
@@ -272,15 +284,16 @@ contract RegistryTest is UnitTestHelper {
         uint256 urcBalanceBefore = address(registry).balance;
 
         vm.prank(bob);
-        uint256 slashedCollateralWei = registry.slashRegistration(registrationRoot, registrations[0], proof, leafIndex);
+        uint256 rewardCollateralWei = registry.slashRegistration(registrationRoot, registrations[0], proof, leafIndex);
 
         _verifySlashingBalances(
-            bob, alice, slashedCollateralWei, 0, collateral, bobBalanceBefore, aliceBalanceBefore, urcBalanceBefore
+            bob, alice, 0, rewardCollateralWei, collateral, bobBalanceBefore, aliceBalanceBefore, urcBalanceBefore
         );
     }
 
     function test_slashRegistrationHeight2_DifferentWithdrawalAddress() public {
-        (uint16 unregistrationDelay, uint256 collateral) = _setupBasicRegistrationParams();
+        (uint16 unregistrationDelay, uint256 minCollateral) = _setupBasicRegistrationParams();
+        uint256 collateral = 2 * minCollateral;
 
         IRegistry.Registration[] memory registrations = new IRegistry.Registration[](2);
         registrations[0] = _createRegistration(SECRET_KEY_1, alice, unregistrationDelay);
@@ -313,15 +326,16 @@ contract RegistryTest is UnitTestHelper {
         uint256 urcBalanceBefore = address(registry).balance;
 
         vm.prank(alice);
-        uint256 slashedCollateralWei = registry.slashRegistration(registrationRoot, registrations[0], proof, leafIndex);
+        uint256 rewardCollateralWei = registry.slashRegistration(registrationRoot, registrations[0], proof, leafIndex);
 
         _verifySlashingBalances(
-            alice, bob, slashedCollateralWei, 0, collateral, bobBalanceBefore, aliceBalanceBefore, urcBalanceBefore
+            alice, bob, 0, rewardCollateralWei, collateral, bobBalanceBefore, aliceBalanceBefore, urcBalanceBefore
         );
     }
 
     function test_verifyMerkleProofHeight3() public {
-        (uint16 unregistrationDelay, uint256 collateral) = _setupBasicRegistrationParams();
+        (uint16 unregistrationDelay, uint256 minCollateral) = _setupBasicRegistrationParams();
+        uint256 collateral = 3 * minCollateral;
 
         IRegistry.Registration[] memory registrations = new IRegistry.Registration[](3); // will be padded to 4
 
@@ -355,7 +369,8 @@ contract RegistryTest is UnitTestHelper {
     function test_fuzzRegister(uint8 n) public {
         vm.assume(n > 0);
         uint256 size = uint256(n);
-        (uint16 unregistrationDelay, uint256 collateral) = _setupBasicRegistrationParams();
+        (uint16 unregistrationDelay, uint256 minCollateral) = _setupBasicRegistrationParams();
+        uint256 collateral = size * minCollateral;
 
         IRegistry.Registration[] memory registrations = new IRegistry.Registration[](size);
         for (uint256 i = 0; i < size; i++) {
@@ -377,14 +392,14 @@ contract RegistryTest is UnitTestHelper {
     function test_slashRegistrationFuzz_DifferentUnregDelay(uint8 n) public {
         vm.assume(n > 0);
         uint256 size = uint256(n);
-        (uint16 unregistrationDelay, uint256 collateral) = _setupBasicRegistrationParams();
+        (uint16 unregistrationDelay, uint256 minCollateral) = _setupBasicRegistrationParams();
 
         IRegistry.Registration[] memory registrations = new IRegistry.Registration[](size);
         for (uint256 i = 0; i < size; i++) {
             registrations[i] = _createRegistration(SECRET_KEY_1 + i, alice, unregistrationDelay);
         }
 
-        bytes32 registrationRoot = registry.register{ value: collateral }(
+        bytes32 registrationRoot = registry.register{ value: minCollateral }(
             registrations,
             alice,
             unregistrationDelay + 1 // submit different delay than the one signed by validator keys
@@ -400,15 +415,15 @@ contract RegistryTest is UnitTestHelper {
         for (uint256 i = 0; i < leaves.length; i++) {
             bytes32[] memory proof = MerkleTree.generateProof(leaves, i);
             vm.prank(bob);
-            uint256 slashedCollateralWei = registry.slashRegistration(registrationRoot, registrations[i], proof, i);
+            registry.slashRegistration(registrationRoot, registrations[i], proof, i);
             _verifySlashingBalances(
-                bob, alice, slashedCollateralWei, 0, collateral, bobBalanceBefore, aliceBalanceBefore, urcBalanceBefore
+                bob, alice, 0, minCollateral, minCollateral, bobBalanceBefore, aliceBalanceBefore, urcBalanceBefore
             );
 
             _assertRegistration(registrationRoot, address(0), 0, 0, 0, 0);
 
             // Re-register to reset the state
-            registrationRoot = registry.register{ value: collateral }(
+            registrationRoot = registry.register{ value: minCollateral }(
                 registrations,
                 alice,
                 unregistrationDelay + 1 // submit different delay than the one signed by validator keys
@@ -424,14 +439,14 @@ contract RegistryTest is UnitTestHelper {
     function test_slashRegistrationFuzz_DifferentWithdrawalAddress(uint8 n) public {
         vm.assume(n > 0);
         uint256 size = uint256(n);
-        (uint16 unregistrationDelay, uint256 collateral) = _setupBasicRegistrationParams();
+        (uint16 unregistrationDelay, uint256 minCollateral) = _setupBasicRegistrationParams();
 
         IRegistry.Registration[] memory registrations = new IRegistry.Registration[](size);
         for (uint256 i = 0; i < size; i++) {
             registrations[i] = _createRegistration(SECRET_KEY_1 + i, alice, unregistrationDelay);
         }
 
-        bytes32 registrationRoot = registry.register{ value: collateral }(
+        bytes32 registrationRoot = registry.register{ value: minCollateral }(
             registrations,
             bob, // submit different withdrawal address than the one signed by validator keys
             unregistrationDelay
@@ -447,15 +462,15 @@ contract RegistryTest is UnitTestHelper {
         for (uint256 i = 0; i < leaves.length; i++) {
             bytes32[] memory proof = MerkleTree.generateProof(leaves, i);
             vm.prank(bob);
-            uint256 slashedCollateralWei = registry.slashRegistration(registrationRoot, registrations[i], proof, i);
+            registry.slashRegistration(registrationRoot, registrations[i], proof, i);
             _verifySlashingBalances(
-                bob, alice, slashedCollateralWei, 0, collateral, bobBalanceBefore, aliceBalanceBefore, urcBalanceBefore
+                bob, alice, 0, minCollateral, minCollateral, bobBalanceBefore, aliceBalanceBefore, urcBalanceBefore
             );
 
             _assertRegistration(registrationRoot, address(0), 0, 0, 0, 0);
 
             // Re-register to reset the state
-            registrationRoot = registry.register{ value: collateral }(
+            registrationRoot = registry.register{ value: minCollateral }(
                 registrations,
                 bob, // submit different withdrawal address than the one signed by validator keys
                 unregistrationDelay
@@ -469,7 +484,9 @@ contract RegistryTest is UnitTestHelper {
     }
 
     function test_unregister() public {
-        (uint16 unregistrationDelay, uint256 collateral) = _setupBasicRegistrationParams();
+        (uint16 unregistrationDelay, uint256 minCollateral) = _setupBasicRegistrationParams();
+        uint256 collateral = 2 * minCollateral;
+
         IRegistry.Registration[] memory registrations =
             _setupSingleRegistration(SECRET_KEY_1, alice, unregistrationDelay);
 
@@ -486,7 +503,9 @@ contract RegistryTest is UnitTestHelper {
     }
 
     function test_unregister_wrongOperator() public {
-        (uint16 unregistrationDelay, uint256 collateral) = _setupBasicRegistrationParams();
+        (uint16 unregistrationDelay, uint256 minCollateral) = _setupBasicRegistrationParams();
+        uint256 collateral = 2 * minCollateral;
+
         IRegistry.Registration[] memory registrations =
             _setupSingleRegistration(SECRET_KEY_1, alice, unregistrationDelay);
 
@@ -499,7 +518,9 @@ contract RegistryTest is UnitTestHelper {
     }
 
     function test_unregister_alreadyUnregistered() public {
-        (uint16 unregistrationDelay, uint256 collateral) = _setupBasicRegistrationParams();
+        (uint16 unregistrationDelay, uint256 minCollateral) = _setupBasicRegistrationParams();
+        uint256 collateral = 2 * minCollateral;
+
         IRegistry.Registration[] memory registrations =
             _setupSingleRegistration(SECRET_KEY_1, alice, unregistrationDelay);
 
@@ -515,7 +536,9 @@ contract RegistryTest is UnitTestHelper {
     }
 
     function test_claimCollateral() public {
-        (uint16 unregistrationDelay, uint256 collateral) = _setupBasicRegistrationParams();
+        (uint16 unregistrationDelay, uint256 minCollateral) = _setupBasicRegistrationParams();
+        uint256 collateral = 2 * minCollateral;
+
         IRegistry.Registration[] memory registrations =
             _setupSingleRegistration(SECRET_KEY_1, alice, unregistrationDelay);
 
@@ -542,7 +565,9 @@ contract RegistryTest is UnitTestHelper {
     }
 
     function test_claimCollateral_notUnregistered() public {
-        (uint16 unregistrationDelay, uint256 collateral) = _setupBasicRegistrationParams();
+        (uint16 unregistrationDelay, uint256 minCollateral) = _setupBasicRegistrationParams();
+        uint256 collateral = 2 * minCollateral;
+
         IRegistry.Registration[] memory registrations =
             _setupSingleRegistration(SECRET_KEY_1, alice, unregistrationDelay);
 
@@ -555,7 +580,9 @@ contract RegistryTest is UnitTestHelper {
     }
 
     function test_claimCollateral_delayNotMet() public {
-        (uint16 unregistrationDelay, uint256 collateral) = _setupBasicRegistrationParams();
+        (uint16 unregistrationDelay, uint256 minCollateral) = _setupBasicRegistrationParams();
+        uint256 collateral = 2 * minCollateral;
+
         IRegistry.Registration[] memory registrations =
             _setupSingleRegistration(SECRET_KEY_1, alice, unregistrationDelay);
 
@@ -573,7 +600,9 @@ contract RegistryTest is UnitTestHelper {
     }
 
     function test_claimCollateral_alreadyClaimed() public {
-        (uint16 unregistrationDelay, uint256 collateral) = _setupBasicRegistrationParams();
+        (uint16 unregistrationDelay, uint256 minCollateral) = _setupBasicRegistrationParams();
+        uint256 collateral = 2 * minCollateral;
+
         IRegistry.Registration[] memory registrations =
             _setupSingleRegistration(SECRET_KEY_1, alice, unregistrationDelay);
 
@@ -594,7 +623,8 @@ contract RegistryTest is UnitTestHelper {
     }
 
     function test_addCollateral(uint56 addAmount) public {
-        (uint16 unregistrationDelay, uint256 collateral) = _setupBasicRegistrationParams();
+        (uint16 unregistrationDelay, uint256 minCollateral) = _setupBasicRegistrationParams();
+        uint256 collateral = 2 * minCollateral;
         vm.assume((addAmount + collateral) / 1 gwei < uint256(2 ** 56));
 
         IRegistry.Registration[] memory registrations =
@@ -615,7 +645,9 @@ contract RegistryTest is UnitTestHelper {
     }
 
     function test_addCollateral_overflow() public {
-        (uint16 unregistrationDelay, uint256 collateral) = _setupBasicRegistrationParams();
+        (uint16 unregistrationDelay, uint256 minCollateral) = _setupBasicRegistrationParams();
+        uint256 collateral = 2 * minCollateral;
+
         IRegistry.Registration[] memory registrations =
             _setupSingleRegistration(SECRET_KEY_1, alice, unregistrationDelay);
 
@@ -662,12 +694,19 @@ contract RegistryTest is UnitTestHelper {
 
         vm.prank(address(reentrantContract));
         vm.expectEmit(address(registry));
-        emit IRegistry.CollateralClaimed(reentrantContract.registrationRoot(), uint256(1 ether / 1 gwei));
+        emit IRegistry.CollateralClaimed(
+            reentrantContract.registrationRoot(),
+            reentrantContract.collateral() / 1 gwei
+        );
 
         // initiate reentrancy
         reentrantContract.claimCollateral();
 
-        assertEq(address(reentrantContract).balance, balanceBefore + 1 ether, "Collateral not returned");
+        assertEq(
+            address(reentrantContract).balance,
+            balanceBefore + reentrantContract.collateral(),
+            "Collateral not returned"
+        );
 
         // Verify registration was deleted
         (address withdrawalAddress,,,,) = registry.registrations(reentrantContract.registrationRoot());
@@ -695,7 +734,7 @@ contract RegistryTest is UnitTestHelper {
         _assertRegistration(
             reentrantContract.registrationRoot(),
             address(reentrantContract),
-            uint56(1 ether / 1 gwei),
+            uint56(reentrantContract.collateral() / 1 gwei),
             uint32(block.number),
             type(uint32).max,
             unregistrationDelay
@@ -704,10 +743,6 @@ contract RegistryTest is UnitTestHelper {
         // generate merkle proof
         bytes32[] memory leaves = _hashToLeaves(registrations);
         bytes32[] memory proof = MerkleTree.generateProof(leaves, 0);
-
-        uint256 bobBalanceBefore = bob.balance;
-        uint256 aliceBalanceBefore = alice.balance;
-        uint256 urcBalanceBefore = address(registry).balance;
 
         // bob can slash the registration
         vm.startPrank(bob);

--- a/test/Registry.t.sol
+++ b/test/Registry.t.sol
@@ -60,11 +60,7 @@ contract RegistryTest is UnitTestHelper {
 
         registrations[0] = _createRegistration(SECRET_KEY_1, alice, unregistrationDelay);
 
-        bytes32 registrationRoot = registry.register{ value: minCollateral }(
-            registrations,
-            alice,
-            unregistrationDelay
-        );
+        bytes32 registrationRoot = registry.register{ value: minCollateral }(registrations, alice, unregistrationDelay);
 
         _assertRegistration(
             registrationRoot,
@@ -87,11 +83,7 @@ contract RegistryTest is UnitTestHelper {
 
         registrations[0] = _createRegistration(SECRET_KEY_1, alice, unregistrationDelay);
 
-        bytes32 registrationRoot = registry.register{ value: minCollateral }(
-            registrations,
-            alice,
-            unregistrationDelay
-        );
+        bytes32 registrationRoot = registry.register{ value: minCollateral }(registrations, alice, unregistrationDelay);
 
         _assertRegistration(
             registrationRoot,
@@ -694,10 +686,7 @@ contract RegistryTest is UnitTestHelper {
 
         vm.prank(address(reentrantContract));
         vm.expectEmit(address(registry));
-        emit IRegistry.CollateralClaimed(
-            reentrantContract.registrationRoot(),
-            reentrantContract.collateral() / 1 gwei
-        );
+        emit IRegistry.CollateralClaimed(reentrantContract.registrationRoot(), reentrantContract.collateral() / 1 gwei);
 
         // initiate reentrancy
         reentrantContract.claimCollateral();

--- a/test/Slasher.t.sol
+++ b/test/Slasher.t.sol
@@ -11,7 +11,7 @@ import { ISlasher } from "../src/ISlasher.sol";
 import { UnitTestHelper, IReentrantContract } from "./UnitTestHelper.sol";
 
 contract DummySlasher is ISlasher {
-    uint256 public SLASH_AMOUNT_GWEI = 1 ether / 1 gwei; 
+    uint256 public SLASH_AMOUNT_GWEI = 1 ether / 1 gwei;
     uint256 public REWARD_AMOUNT_GWEI = 0.1 ether / 1 gwei; // MIN_COLLATERAL
 
     function DOMAIN_SEPARATOR() external view returns (bytes memory) {
@@ -70,7 +70,10 @@ contract DummySlasherTest is UnitTestHelper {
         vm.startPrank(bob);
         vm.expectEmit(address(registry));
         emit IRegistry.OperatorSlashed(
-            result.registrationRoot, dummySlasher.SLASH_AMOUNT_GWEI(), dummySlasher.REWARD_AMOUNT_GWEI(), result.signedDelegation.delegation.proposerPubKey
+            result.registrationRoot,
+            dummySlasher.SLASH_AMOUNT_GWEI(),
+            dummySlasher.REWARD_AMOUNT_GWEI(),
+            result.signedDelegation.delegation.proposerPubKey
         );
         (uint256 gotSlashAmountGwei, uint256 gotRewardAmountGwei) = registry.slashCommitment(
             result.registrationRoot,
@@ -84,7 +87,14 @@ contract DummySlasherTest is UnitTestHelper {
 
         // verify balances updated correctly
         _verifySlashingBalances(
-            bob, alice, dummySlasher.SLASH_AMOUNT_GWEI() * 1 gwei, dummySlasher.REWARD_AMOUNT_GWEI() * 1 gwei, collateral, bobBalanceBefore, aliceBalanceBefore, urcBalanceBefore
+            bob,
+            alice,
+            dummySlasher.SLASH_AMOUNT_GWEI() * 1 gwei,
+            dummySlasher.REWARD_AMOUNT_GWEI() * 1 gwei,
+            collateral,
+            bobBalanceBefore,
+            aliceBalanceBefore,
+            urcBalanceBefore
         );
 
         // Verify operator was deleted
@@ -316,15 +326,13 @@ contract DummySlasherTest is UnitTestHelper {
         vm.startPrank(alice);
         vm.expectEmit(address(registry));
         emit IRegistry.OperatorSlashed(
-            result.registrationRoot, dummySlasher.SLASH_AMOUNT_GWEI(), dummySlasher.REWARD_AMOUNT_GWEI(), result.signedDelegation.delegation.proposerPubKey
+            result.registrationRoot,
+            dummySlasher.SLASH_AMOUNT_GWEI(),
+            dummySlasher.REWARD_AMOUNT_GWEI(),
+            result.signedDelegation.delegation.proposerPubKey
         );
         (uint256 gotSlashAmountGwei, uint256 gotRewardAmountGwei) = registry.slashCommitment(
-            result.registrationRoot,
-            result.registrations[0].signature,
-            proof,
-            0,
-            result.signedDelegation,
-            evidence
+            result.registrationRoot, result.registrations[0].signature, proof, 0, result.signedDelegation, evidence
         );
         assertEq(dummySlasher.SLASH_AMOUNT_GWEI(), gotSlashAmountGwei, "Slash amount incorrect");
 


### PR DESCRIPTION
Closes #22 

Reworks the Slasher.slash() interface to return a `rewardAmountGwei`. The reasoning is that the old `slash()` function could be frontrun by the slashed operator and reclaim all of their collateral, eroding the credibility of the commitment. Now, the Slasher contract is expected to return the amount of Ether to be burned and the amount to reward the challenger. 

The URC makes no assumptions about the `rewardAmountGwei` and `slashAmountGwei` to remain as unopinionated as possible. Instead, it is up to the proposer commitment protocols to define this and the consuming applications to deem the amounts to provide sufficient security. For example, setting `rewardAmountGwei` too low could be insecure as it disincentivizes challengers, while setting `rewardAmountGwei` too high can erode the credibility of the commitment if the call to `slash()` is frontrun. 