### PR TITLE
Issue 14 - Inclusion Preconf Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ forge test
 ### Design
 See the [docs](./docs/overview.md) for more information.
 
+### Examples
+See the [examples](./example/README.md) for reference implementations of Slasher contracts.
+
 ### References
 - Justin Drake’s proposed requirements
     > 1. The contract is super simple and short (ideally ~100 lines).

--- a/example/ExclusionPreconfSlasher.sol
+++ b/example/ExclusionPreconfSlasher.sol
@@ -60,7 +60,8 @@ contract ExclusionPreconfSlasher is ISlasher {
 
     function slash(
         ISlasher.Delegation calldata delegation,
-        bytes calldata evidence
+        bytes calldata evidence,
+        address challenger
     ) external returns (uint256 slashAmountGwei, uint256 rewardAmountGwei) {
         // Operator delegated to an ECDSA signer as part of the metadata field
         address commitmentSigner = abi.decode(delegation.metadata, (address));

--- a/example/ExclusionPreconfSlasher.sol
+++ b/example/ExclusionPreconfSlasher.sol
@@ -41,7 +41,7 @@ contract ExclusionPreconfSlasher is ISlasher {
     error InvalidBlockNumber();
     error InvalidBlockHash();
     error BeaconRootNotFound();
-
+    error DelegationExpired();
     constructor(uint256 _slashAmountGwei, uint256 _rewardAmountGwei) {
         SLASH_AMOUNT_GWEI = _slashAmountGwei;
         REWARD_AMOUNT_GWEI = _rewardAmountGwei;
@@ -75,6 +75,11 @@ contract ExclusionPreconfSlasher is ISlasher {
                 evidence,
                 (PreconfStructs.SignedCommitment, PreconfStructs.InclusionProof)
             );
+        
+        // Check if the delegation applies to the slot of the commitment
+        if (delegation.validUntil < commitment.slot) {
+            revert DelegationExpired();
+        }
 
         // If the inclusion proof is valid (doesn't revert) they should be slashed for not excluding the transaction
         _verifyInclusionProof(commitment, proof, commitmentSigner);

--- a/example/PreconfStructs.sol
+++ b/example/PreconfStructs.sol
@@ -20,7 +20,7 @@ interface PreconfStructs {
     error EthTransferFailed();
     error WrongChallengerAddress();
     error FraudProofWindowActive();
-
+    error NotURC();
     struct Challenge {
         address challenger;
         uint256 challengeTimestamp;

--- a/example/PreconfStructs.sol
+++ b/example/PreconfStructs.sol
@@ -3,7 +3,29 @@ pragma solidity >=0.8.0 <0.9.0;
 
 // Adapted from https://github.com/chainbound/bolt/tree/unstable/bolt-contracts
 
-contract PreconfStructs {
+interface PreconfStructs {
+    error BlockIsNotFinalized();
+    error InvalidParentBlockHash();
+    error UnexpectedSigner();
+    error TransactionExcluded();
+    error WrongTransactionHashProof();
+    error BlockIsTooOld();
+    error InvalidBlockNumber();
+    error InvalidBlockHash();
+    error BeaconRootNotFound();
+    error DelegationExpired();
+    error IncorrectChallengeBond();
+    error ChallengeAlreadyExists();
+    error ChallengeDoesNotExist();
+    error EthTransferFailed();
+    error WrongChallengerAddress();
+    error FraudProofWindowActive();
+
+    struct Challenge {
+        address challenger;
+        uint256 challengeTimestamp;
+    }
+
     struct SignedCommitment {
         uint64 slot;
         bytes signature;

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,15 @@
+# Example Slasher Implementations
+
+## InclusionPreconfSlasher
+
+## ExclusionPreconfSlasher
+1. Operator calls URC's [register()](../src/Registry.sol#L44) function to register a proposer BLS key
+2. Operator signs an off-chain [`Delegation`](../src/ISlasher.sol#L8) message, delegating to a delegate's BLS key and committing to the slashing rules of the [`ExclusionPreconfSlasher`](./ExclusionPreconfSlasher.sol) contract. Included in the `Delegation.metadata` is an address that is the ECDSA signer of the [`SignedCommitment`](./PreconfStructs.sol) message. 
+    > Note, embedding the ECDSA signer address in the `Delegation.metadata` field is optional, but simplified this example.
+3. Operator signs an off-chain [`SignedCommitment`](./PreconfStructs.sol) message, committing to the exclusion of a specific transaction.
+4. L1 block is published with the transaction included, breaking the preconf promise.
+5. Challenger builds evidence for slashing:
+    - produces an off-chain [`InclusionProof`](./PreconfStructs.sol) message, proving the preconfed transaction was included in the L1 block. The `SignedCommitment` and `InclusionProof` structs are abi-encoded and supplied as the `evidence` argument to the [`slashCommitment()`](../src/Registry.sol) function.
+    - produces a Merkle proof that the operator's BLS key is registered in the URC (`proof` argument)
+6. Challenger calls [`slashCommitment()`](../src/Registry.sol) with the evidence. The URC will verify that the `Delegation` message was signed by the registered proposer BLS key and then call the [`slash()`](../src/ISlasher.sol) function at the `Delegation.slasher` address. This will execute the [`ExclusionPreconfSlasher.slash()`](./ExclusionPreconfSlasher.sol) function.
+7. The ExclusionPreconfSlasher will decode the `evidence` argument, verify the SignedCommitment was signed by the ECDSA signer in the `Delegation.metadata` field, then verify the inclusion proof against the L1 block. If the proof is valid, it means the preconfed transaction was included in the L1 block, and the slashing logic will execute and the operator will be slashed. Specifically, the slashing logic will return the `slashAmountGwei` and `rewardAmountGwei` values, which are the amount of GWEI to be burned and the amount of GWEI to be returned to the challenger, respectively, where the accounting is handled by the URC.

--- a/src/IRegistry.sol
+++ b/src/IRegistry.sol
@@ -113,7 +113,6 @@ interface IRegistry {
     error FraudProofMerklePathInvalid();
     error FraudProofChallengeInvalid();
     error CollateralOverflow();
-    error DelegationExpired();
     error OperatorAlreadyUnregistered();
     /**
      *

--- a/src/ISlasher.sol
+++ b/src/ISlasher.sol
@@ -30,9 +30,10 @@ interface ISlasher {
     /// @dev The URC will call this function to slash a registered operator if supplied with a valid delegation and evidence
     /// @param delegation The delegation message
     /// @param evidence Arbitrary evidence for the slashing
+    /// @param challenger The address of the challenger
     /// @return slashAmountGwei The amount of Gwei slashed
     /// @return rewardAmountGwei The amount of Gwei rewarded to the caller
-    function slash(Delegation calldata delegation, bytes calldata evidence)
+    function slash(Delegation calldata delegation, bytes calldata evidence, address challenger)
         external
         returns (uint256 slashAmountGwei, uint256 rewardAmountGwei);
 

--- a/src/Registry.sol
+++ b/src/Registry.sol
@@ -367,7 +367,7 @@ contract Registry is IRegistry {
         uint256 collateralGwei
     ) internal returns (uint256 slashAmountGwei, uint256 rewardAmountGwei) {
         (slashAmountGwei, rewardAmountGwei) =
-            ISlasher(signedDelegation.delegation.slasher).slash(signedDelegation.delegation, evidence);
+            ISlasher(signedDelegation.delegation.slasher).slash(signedDelegation.delegation, evidence, msg.sender);
 
         if (slashAmountGwei > collateralGwei) {
             revert SlashAmountExceedsCollateral();

--- a/src/Registry.sol
+++ b/src/Registry.sol
@@ -345,11 +345,6 @@ contract Registry is IRegistry {
         // Reconstruct Delegation message
         bytes memory message = abi.encode(signedDelegation.delegation);
 
-        // Check if the delegation is fresh
-        if (signedDelegation.delegation.validUntil < _getSlotFromTimestamp(block.timestamp)) {
-            revert DelegationExpired();
-        }
-
         // Recover Slasher contract domain separator
         bytes memory domainSeparator = ISlasher(signedDelegation.delegation.slasher).DOMAIN_SEPARATOR();
 

--- a/test/ExclusionPreconfSlasher.t.sol
+++ b/test/ExclusionPreconfSlasher.t.sol
@@ -183,12 +183,12 @@ contract ExclusionPreconfSlasherTest is UnitTestHelper {
         bytes32[] memory registrationProof = MerkleTree.generateProof(leaves, leafIndex);
 
         // Save for comparison after slashing
-        uint256 bobBalanceBefore = bob.balance;
-        uint256 aliceBalanceBefore = alice.balance;
+        uint256 challengerBalanceBefore = challenger.balance;
+        uint256 operatorBalanceBefore = operator.balance;
         uint256 urcBalanceBefore = address(registry).balance;
 
         // Slash via URC
-        vm.prank(bob);
+        vm.startPrank(challenger);
         registry.slashCommitment(
             result.registrationRoot,
             result.registrations[0].signature,
@@ -200,13 +200,13 @@ contract ExclusionPreconfSlasherTest is UnitTestHelper {
 
         // verify balances updated correctly
         _verifySlashingBalances(
-            bob,
-            alice,
+            challenger,
+            operator,
             slashAmountGwei * 1 gwei,
             rewardAmountGwei * 1 gwei,
             collateral,
-            bobBalanceBefore,
-            aliceBalanceBefore,
+            challengerBalanceBefore,
+            operatorBalanceBefore,
             urcBalanceBefore
         );
 

--- a/test/InclusionPreconfSlasher.t.sol
+++ b/test/InclusionPreconfSlasher.t.sol
@@ -1,0 +1,437 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0 <0.9.0;
+
+// Adapted from https://github.com/chainbound/bolt/tree/unstable/bolt-contracts
+
+import {console} from "forge-std/Test.sol";
+
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+
+import {RLPReader} from "../example/lib/rlp/RLPReader.sol";
+import {RLPWriter} from "../example/lib/rlp/RLPWriter.sol";
+import {BytesUtils} from "../example/lib/BytesUtils.sol";
+import {MerkleTrie} from "../example/lib/trie/MerkleTrie.sol";
+import {SecureMerkleTrie} from "../example/lib/trie/SecureMerkleTrie.sol";
+import {TransactionDecoder} from "../example/lib/TransactionDecoder.sol";
+import {Registry} from "../src/Registry.sol";
+import {BLS} from "../src/lib/BLS.sol";
+import {MerkleTree} from "../src/lib/MerkleTree.sol";
+import {PreconfStructs} from "../example/PreconfStructs.sol";
+import {InclusionPreconfSlasher} from "../example/InclusionPreconfSlasher.sol";
+import {UnitTestHelper} from "./UnitTestHelper.sol";
+
+contract InclusionPreconfSlasherTest is UnitTestHelper {
+    using RLPReader for bytes;
+    using RLPReader for RLPReader.RLPItem;
+    using BytesUtils for bytes;
+    using TransactionDecoder for TransactionDecoder.Transaction;
+    using TransactionDecoder for bytes;
+
+    InclusionPreconfSlasher slasher;
+    BLS.G1Point delegatePubKey;
+    uint256 slashAmountGwei = 1 ether / 1 gwei; // slash 1 ether
+    uint256 rewardAmountGwei = 0.1 ether / 1 gwei; // reward 0.1 ether
+    uint256 collateral = 1.1 ether;
+
+    function setUp() public {
+        vm.createSelectFork(vm.rpcUrl("mainnet"));
+        registry = new Registry();
+        slasher = new InclusionPreconfSlasher(
+            slashAmountGwei,
+            rewardAmountGwei,
+            address(registry)
+        );
+        delegatePubKey = BLS.toPublicKey(SECRET_KEY_2);
+        vm.deal(challenger, 100 ether);
+        vm.deal(operator, 100 ether);
+    }
+
+    function setupRegistration(
+        address operator,
+        address delegate
+    ) internal returns (RegisterAndDelegateResult memory result) {
+        // Prepare the metadata for the delegation, delegating to the delegate to sign exclusion commitments
+        bytes memory metadata = abi.encode(delegate);
+
+        // Register operator to URC
+        RegisterAndDelegateParams memory params = RegisterAndDelegateParams({
+            proposerSecretKey: SECRET_KEY_1,
+            collateral: collateral,
+            withdrawalAddress: operator,
+            delegateSecretKey: SECRET_KEY_2,
+            slasher: address(slasher),
+            domainSeparator: slasher.DOMAIN_SEPARATOR(),
+            metadata: metadata,
+            validUntil: uint64(UINT256_MAX)
+        });
+
+        // Register operator to URC and signs delegation message
+        vm.prank(operator);
+        result = registerAndDelegate(params);
+    }
+
+    function setupSlash(
+        uint256 id
+    )
+        public
+        returns (
+            RegisterAndDelegateResult memory result,
+            bytes memory evidence,
+            PreconfStructs.SignedCommitment memory commitment
+        )
+    {
+        uint256 inclusionBlockNumber = 20_785_012;
+        // Create ecdsa keypair for delegate
+        (address delegate, uint256 delegatePK) = makeAddrAndKey("delegate");
+
+        // Advance before the fraud proof window
+        vm.roll(inclusionBlockNumber - registry.FRAUD_PROOF_WINDOW());
+        vm.warp(inclusionBlockNumber - registry.FRAUD_PROOF_WINDOW() * 12);
+
+        // Register and delegate
+        result = setupRegistration(operator, delegate);
+
+        // Advance over registration fraud proof window to the target slot
+        vm.roll(inclusionBlockNumber);
+        vm.warp(slasher._getTimestampFromSlot(9994114)); // https://etherscan.io/block/20785012
+
+        // Delegate signs a commitment to include a TX
+        commitment = _createInclusionCommitment(
+            inclusionBlockNumber,
+            id,
+            delegate,
+            delegatePK
+        );
+
+        // Build the inclusion proof to prove failure to exclude
+        string memory rawPreviousHeader = vm.readFile(
+            "./test/testdata/header_20785011.json"
+        );
+        string memory rawInclusionHeader = vm.readFile(
+            "./test/testdata/header_20785012.json"
+        );
+        string memory ethProof = vm.readFile(
+            "./test/testdata/eth_proof_20785011.json"
+        );
+        string memory txProof = vm.readFile(
+            "./test/testdata/tx_mpt_proof_20785012.json"
+        );
+
+        bytes[] memory txProofs = new bytes[](1);
+        txProofs[0] = _RLPEncodeList(vm.parseJsonBytesArray(txProof, ".proof"));
+
+        uint256[] memory txIndexesInBlock = new uint256[](1);
+        txIndexesInBlock[0] = vm.parseJsonUint(txProof, ".index");
+
+        PreconfStructs.InclusionProof memory inclusionProof = PreconfStructs
+            .InclusionProof({
+                inclusionBlockNumber: inclusionBlockNumber,
+                previousBlockHeaderRLP: vm.parseJsonBytes(
+                    rawPreviousHeader,
+                    ".result"
+                ),
+                inclusionBlockHeaderRLP: vm.parseJsonBytes(
+                    rawInclusionHeader,
+                    ".result"
+                ),
+                accountMerkleProof: _RLPEncodeList(
+                    vm.parseJsonBytesArray(ethProof, ".result.accountProof")
+                ),
+                txMerkleProofs: txProofs,
+                txIndexesInBlock: txIndexesInBlock
+            });
+
+        // check that the inclusion block transactions root matches the root in the tx proof data.
+        bytes32 inclusionTxRoot = slasher
+            ._decodeBlockHeaderRLP(inclusionProof.inclusionBlockHeaderRLP)
+            .txRoot;
+        assertEq(inclusionTxRoot, vm.parseJsonBytes32(txProof, ".root"));
+
+        evidence = abi.encode(commitment, inclusionProof);
+    }
+
+    function test_challenge() public {
+        (
+            RegisterAndDelegateResult memory result,
+            bytes memory evidence,
+            PreconfStructs.SignedCommitment memory commitment
+        ) = setupSlash(1);
+
+        bytes32 challengeID = slasher.createChallenge{
+            value: slasher.CHALLENGE_BOND()
+        }(commitment, result.signedDelegation);
+        assertEq(
+            challengeID,
+            keccak256(abi.encode(commitment, result.signedDelegation))
+        );
+    }
+
+    function test_revert_challenge_incorrectBond() public {
+        (
+            RegisterAndDelegateResult memory result,
+            ,
+            PreconfStructs.SignedCommitment memory commitment
+        ) = setupSlash(1);
+
+        uint256 bond = slasher.CHALLENGE_BOND() - 1;
+        // Try with incorrect bond amount
+        vm.expectRevert(PreconfStructs.IncorrectChallengeBond.selector);
+        slasher.createChallenge{value: bond}(
+            commitment,
+            result.signedDelegation
+        );
+    }
+
+    function test_revert_challenge_alreadyExists() public {
+        (
+            RegisterAndDelegateResult memory result,
+            ,
+            PreconfStructs.SignedCommitment memory commitment
+        ) = setupSlash(1);
+
+        uint256 bond = slasher.CHALLENGE_BOND();
+        // Create first challenge
+        slasher.createChallenge{value: bond}(
+            commitment,
+            result.signedDelegation
+        );
+
+        // Try to create duplicate challenge
+        vm.expectRevert(PreconfStructs.ChallengeAlreadyExists.selector);
+        slasher.createChallenge{value: bond}(
+            commitment,
+            result.signedDelegation
+        );
+    }
+
+    function test_revert_challenge_expiredDelegation() public {
+        uint256 inclusionBlockNumber = 20_785_012;
+        (address alice, ) = makeAddrAndKey("alice_expired");
+        (address delegate, uint256 delegatePK) = makeAddrAndKey("delegate");
+        vm.deal(alice, 100 ether);
+
+        // Set block to before fraud proof window
+        vm.roll(inclusionBlockNumber - registry.FRAUD_PROOF_WINDOW());
+        vm.warp(inclusionBlockNumber - registry.FRAUD_PROOF_WINDOW() * 12);
+
+        // Register with a soon-to-expire delegation
+        bytes memory metadata = abi.encode(delegate);
+        RegisterAndDelegateParams memory params = RegisterAndDelegateParams({
+            proposerSecretKey: SECRET_KEY_1,
+            collateral: collateral,
+            withdrawalAddress: alice,
+            delegateSecretKey: SECRET_KEY_2,
+            slasher: address(slasher),
+            domainSeparator: slasher.DOMAIN_SEPARATOR(),
+            metadata: metadata,
+            validUntil: 0 // already expired
+        });
+        RegisterAndDelegateResult memory result = registerAndDelegate(params);
+
+        // Create commitment for expired delegation
+        vm.roll(inclusionBlockNumber);
+        vm.warp(slasher._getTimestampFromSlot(9994114)); // https://etherscan.io/block/20785012
+        PreconfStructs.SignedCommitment
+            memory commitment = _createInclusionCommitment(
+                inclusionBlockNumber,
+                1,
+                delegate,
+                delegatePK
+            );
+
+        // Try to create challenge with expired delegation
+        uint256 bond = slasher.CHALLENGE_BOND();
+        vm.expectRevert(PreconfStructs.DelegationExpired.selector);
+        slasher.createChallenge{value: bond}(
+            commitment,
+            result.signedDelegation
+        );
+    }
+
+    function test_slash() public {
+        // Register at URC and generate slashable evidence
+        (
+            RegisterAndDelegateResult memory result,
+            bytes memory evidence,
+            PreconfStructs.SignedCommitment memory commitment
+        ) = setupSlash(1);
+
+        // Save initial balances for comparison
+        uint256 challengerBalanceBefore = challenger.balance;
+        uint256 operatorBalanceBefore = operator.balance;
+        uint256 urcBalanceBefore = address(registry).balance;
+        uint256 bond = slasher.CHALLENGE_BOND();
+
+        // Create challenge
+        vm.prank(challenger);
+        bytes32 challengeID = slasher.createChallenge{value: bond}(
+            commitment,
+            result.signedDelegation
+        );
+
+        // Verify challenger's balance decreased by bond amount
+        assertEq(challenger.balance, challengerBalanceBefore - bond);
+
+        // Skip ahead past the challenge window
+        vm.warp(block.timestamp + slasher.CHALLENGE_WINDOW() + 1);
+
+        // Merkle proof for URC registration
+        bytes32[] memory leaves = _hashToLeaves(result.registrations);
+        bytes32[] memory registrationProof = MerkleTree.generateProof(
+            leaves,
+            0 // leaf index
+        );
+
+        // Slash via URC
+        vm.prank(challenger);
+        registry.slashCommitment(
+            result.registrationRoot,
+            result.registrations[0].signature,
+            registrationProof,
+            0, // leaf index
+            result.signedDelegation,
+            evidence
+        );
+
+        _verifySlashingBalances(
+            challenger,
+            operator,
+            slashAmountGwei * 1 gwei,
+            rewardAmountGwei * 1 gwei,
+            collateral,
+            challengerBalanceBefore,
+            operatorBalanceBefore,
+            urcBalanceBefore
+        );
+
+        // Verify operator was deleted
+        _assertRegistration(result.registrationRoot, address(0), 0, 0, 0, 0);
+    }
+
+    function test_revert_slash_wrongChallenger() public {
+        (RegisterAndDelegateResult memory result, bytes memory evidence, PreconfStructs.SignedCommitment memory commitment) = setupSlash(1);
+
+        // Create challenge as the original challenger
+        vm.prank(challenger);
+        bytes32 challengeID = slasher.createChallenge{value: slasher.CHALLENGE_BOND()}(
+            commitment,
+            result.signedDelegation
+        );
+
+        // Skip ahead past the challenge window
+        vm.warp(block.timestamp + slasher.CHALLENGE_WINDOW() + 1);
+
+        // Merkle proof for URC registration
+        bytes32[] memory leaves = _hashToLeaves(result.registrations);
+        uint256 leafIndex = 0;
+        bytes32[] memory registrationProof = MerkleTree.generateProof(leaves, leafIndex);
+
+        // Try to slash as different address (not the original challenger)
+        vm.prank(operator);
+        vm.expectRevert(PreconfStructs.WrongChallengerAddress.selector);
+        registry.slashCommitment(
+            result.registrationRoot,
+            result.registrations[0].signature,
+            registrationProof,
+            leafIndex,
+            result.signedDelegation,
+            evidence
+        );
+    }
+
+    function test_revert_slash_notURC() public {
+        (
+            RegisterAndDelegateResult memory result,
+            bytes memory evidence,
+            PreconfStructs.SignedCommitment memory commitment
+        ) = setupSlash(1);
+
+        // Try to call slash directly (not through URC)
+        vm.expectRevert(PreconfStructs.NotURC.selector);
+        slasher.slash(result.signedDelegation.delegation, evidence, address(0));
+    }
+
+    // function test_proveChallengeFraudulent() public {
+    //     (RegisterAndDelegateResult memory result, bytes memory evidence, PreconfStructs.SignedCommitment memory commitment) = setupSlash(1);
+
+    //     slasher.proveChallengeFraudulent(result.signedDelegation.delegation, commitment, evidence);
+    // }
+
+    // =========== Helper functions ===========
+
+    // Helper to create a test inclusion proof with a recent slot, valid for a recent challenge
+    function _createInclusionCommitment(
+        uint256 blockNumber,
+        uint256 id,
+        address delegate,
+        uint256 delegatePK
+    )
+        internal
+        view
+        returns (PreconfStructs.SignedCommitment memory commitment)
+    {
+        // pattern: ./test/testdata/signed_tx_{blockNumber}_{id}.json
+        string memory base = "./test/testdata/signed_tx_";
+        string memory extension = string.concat(
+            vm.toString(blockNumber),
+            "_",
+            vm.toString(id),
+            ".json"
+        );
+        string memory path = string.concat(base, extension);
+        commitment.signedTx = vm.parseJsonBytes(vm.readFile(path), ".raw");
+
+        commitment.slot = uint64(slasher._getCurrentSlot() - 100);
+
+        // sign the new commitment with the target's private key
+        bytes32 commitmentID = _computeCommitmentID(
+            commitment.signedTx,
+            commitment.slot
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(delegatePK, commitmentID);
+        commitment.signature = abi.encodePacked(r, s, v);
+
+        // Normalize v to 27 or 28
+        if (uint8(commitment.signature[64]) < 27) {
+            commitment.signature[64] = bytes1(
+                uint8(commitment.signature[64]) + 0x1B
+            );
+        }
+
+        // Sanity check
+        assertEq(ECDSA.recover(commitmentID, commitment.signature), delegate);
+
+        return commitment;
+    }
+
+    // Helper to compute the commitment ID
+    function _computeCommitmentID(
+        bytes memory signedTx,
+        uint64 slot
+    ) internal pure returns (bytes32) {
+        return
+            keccak256(
+                abi.encodePacked(keccak256(signedTx), _toLittleEndian(slot))
+            );
+    }
+
+    // Helper to encode a list of bytes[] into an RLP list with each item RLP-encoded
+    function _RLPEncodeList(
+        bytes[] memory _items
+    ) internal pure returns (bytes memory) {
+        bytes[] memory encodedItems = new bytes[](_items.length);
+        for (uint256 i = 0; i < _items.length; i++) {
+            encodedItems[i] = RLPWriter.writeBytes(_items[i]);
+        }
+        return RLPWriter.writeList(encodedItems);
+    }
+
+    // Helper to convert a u64 to a little-endian bytes
+    function _toLittleEndian(uint64 x) internal pure returns (bytes memory) {
+        bytes memory b = new bytes(8);
+        for (uint256 i = 0; i < 8; i++) {
+            b[i] = bytes1(uint8(x >> (8 * i)));
+        }
+        return b;
+    }
+}

--- a/test/Registry.t.sol
+++ b/test/Registry.t.sol
@@ -14,13 +14,14 @@ contract RegistryTest is UnitTestHelper {
 
     function setUp() public {
         registry = new Registry();
-        vm.deal(alice, 100 ether); // Give alice some ETH
-        vm.deal(bob, 100 ether); // Give bob some ETH
+        vm.deal(operator, 100 ether);
+        vm.deal(challenger, 100 ether);
+        vm.deal(thief, 100 ether);
     }
 
     function test_register() public {
         uint256 collateral = registry.MIN_COLLATERAL();
-        basicRegistration(SECRET_KEY_1, collateral, alice);
+        basicRegistration(SECRET_KEY_1, collateral, operator);
     }
 
     function test_register_insufficientCollateral() public {
@@ -28,10 +29,10 @@ contract RegistryTest is UnitTestHelper {
 
         IRegistry.Registration[] memory registrations = new IRegistry.Registration[](1);
 
-        registrations[0] = _createRegistration(SECRET_KEY_1, alice, unregistrationDelay);
+        registrations[0] = _createRegistration(SECRET_KEY_1, operator, unregistrationDelay);
 
         vm.expectRevert(IRegistry.InsufficientCollateral.selector);
-        registry.register{ value: minCollateral - 1 }(registrations, alice, unregistrationDelay);
+        registry.register{ value: minCollateral - 1 }(registrations, operator, unregistrationDelay);
     }
 
     function test_register_unregistrationDelayTooShort() public {
@@ -41,14 +42,14 @@ contract RegistryTest is UnitTestHelper {
 
         registrations[0] = _createRegistration(
             SECRET_KEY_1,
-            alice,
+            operator,
             unregistrationDelay // delay that is signed by validator key
         );
 
         vm.expectRevert(IRegistry.UnregistrationDelayTooShort.selector);
         registry.register{ value: minCollateral }(
             registrations,
-            alice,
+            operator,
             unregistrationDelay - 1 // submit shorter delay than the one signed by validator key
         );
     }
@@ -58,13 +59,13 @@ contract RegistryTest is UnitTestHelper {
 
         IRegistry.Registration[] memory registrations = new IRegistry.Registration[](1);
 
-        registrations[0] = _createRegistration(SECRET_KEY_1, alice, unregistrationDelay);
+        registrations[0] = _createRegistration(SECRET_KEY_1, operator, unregistrationDelay);
 
-        bytes32 registrationRoot = registry.register{ value: minCollateral }(registrations, alice, unregistrationDelay);
+        bytes32 registrationRoot = registry.register{ value: minCollateral }(registrations, operator, unregistrationDelay);
 
         _assertRegistration(
             registrationRoot,
-            alice,
+            operator,
             uint56(minCollateral / 1 gwei),
             uint32(block.number),
             type(uint32).max,
@@ -73,7 +74,7 @@ contract RegistryTest is UnitTestHelper {
 
         // Attempt duplicate registration
         vm.expectRevert(IRegistry.OperatorAlreadyRegistered.selector);
-        registry.register{ value: minCollateral }(registrations, alice, unregistrationDelay);
+        registry.register{ value: minCollateral }(registrations, operator, unregistrationDelay);
     }
 
     function test_verifyMerkleProofHeight1() public {
@@ -81,13 +82,13 @@ contract RegistryTest is UnitTestHelper {
 
         IRegistry.Registration[] memory registrations = new IRegistry.Registration[](1);
 
-        registrations[0] = _createRegistration(SECRET_KEY_1, alice, unregistrationDelay);
+        registrations[0] = _createRegistration(SECRET_KEY_1, operator, unregistrationDelay);
 
-        bytes32 registrationRoot = registry.register{ value: minCollateral }(registrations, alice, unregistrationDelay);
+        bytes32 registrationRoot = registry.register{ value: minCollateral }(registrations, operator, unregistrationDelay);
 
         _assertRegistration(
             registrationRoot,
-            alice,
+            operator,
             uint56(minCollateral / 1 gwei),
             uint32(block.number),
             type(uint32).max,
@@ -113,19 +114,19 @@ contract RegistryTest is UnitTestHelper {
 
         IRegistry.Registration[] memory registrations = _setupSingleRegistration(
             SECRET_KEY_1,
-            alice,
+            operator,
             unregistrationDelay // delay that is signed by validator key
         );
 
         bytes32 registrationRoot = registry.register{ value: collateral }(
             registrations,
-            alice,
+            operator,
             unregistrationDelay + 1 // submit different delay
         );
 
         _assertRegistration(
             registrationRoot,
-            alice,
+            operator,
             uint56(collateral / 1 gwei),
             uint32(block.number),
             type(uint32).max,
@@ -136,16 +137,16 @@ contract RegistryTest is UnitTestHelper {
         bytes32[] memory leaves = _hashToLeaves(registrations);
         bytes32[] memory proof = MerkleTree.generateProof(leaves, 0);
 
-        uint256 bobBalanceBefore = bob.balance;
-        uint256 aliceBalanceBefore = alice.balance;
+        uint256 challengerBalanceBefore = challenger.balance;
+        uint256 operatorBalanceBefore = operator.balance;
         uint256 urcBalanceBefore = address(registry).balance;
 
-        vm.prank(bob);
+        vm.startPrank(challenger);
         uint256 rewardCollateralWei = registry.slashRegistration(registrationRoot, registrations[0], proof, 0);
         assertEq(rewardCollateralWei, minCollateral, "Wrong rewardCollateralWei amount");
 
         _verifySlashingBalances(
-            bob, alice, 0, rewardCollateralWei, collateral, bobBalanceBefore, aliceBalanceBefore, urcBalanceBefore
+            challenger, operator, 0, rewardCollateralWei, collateral, challengerBalanceBefore, operatorBalanceBefore, urcBalanceBefore
         );
 
         _assertRegistration(registrationRoot, address(0), 0, 0, 0, 0);
@@ -159,19 +160,19 @@ contract RegistryTest is UnitTestHelper {
 
         registrations[0] = _createRegistration(
             SECRET_KEY_1,
-            alice, // withdrawal that is signed by validator key
+            operator, // withdrawal that is signed by validator key
             unregistrationDelay
         );
 
         bytes32 registrationRoot = registry.register{ value: collateral }(
             registrations,
-            bob, // Bob tries to frontrun alice by setting his address as withdrawal address
+            thief, // thief tries to frontrun operator by setting his address as withdrawal address
             unregistrationDelay
         );
 
         _assertRegistration(
             registrationRoot,
-            bob, // confirm bob's address is what was registered
+            thief, // confirm thief's address is what was registered
             uint56(collateral / 1 gwei),
             uint32(block.number),
             type(uint32).max,
@@ -182,12 +183,11 @@ contract RegistryTest is UnitTestHelper {
         bytes32[] memory leaves = _hashToLeaves(registrations);
         bytes32[] memory proof = MerkleTree.generateProof(leaves, 0);
 
-        uint256 bobBalanceBefore = bob.balance;
-        uint256 aliceBalanceBefore = alice.balance;
+        uint256 thiefBalanceBefore = thief.balance;
+        uint256 operatorBalanceBefore = operator.balance;
         uint256 urcBalanceBefore = address(registry).balance;
 
-        // alice is the challenger
-        vm.prank(alice);
+        vm.startPrank(operator);
         uint256 rewardCollateralWei = registry.slashRegistration(
             registrationRoot,
             registrations[0],
@@ -196,7 +196,7 @@ contract RegistryTest is UnitTestHelper {
         );
 
         _verifySlashingBalances(
-            alice, bob, 0, rewardCollateralWei, collateral, bobBalanceBefore, aliceBalanceBefore, urcBalanceBefore
+            operator, thief, 0, rewardCollateralWei, collateral, thiefBalanceBefore, operatorBalanceBefore, urcBalanceBefore
         );
 
         // ensure operator was deleted
@@ -209,15 +209,15 @@ contract RegistryTest is UnitTestHelper {
 
         IRegistry.Registration[] memory registrations = new IRegistry.Registration[](2);
 
-        registrations[0] = _createRegistration(SECRET_KEY_1, alice, unregistrationDelay);
+        registrations[0] = _createRegistration(SECRET_KEY_1, operator, unregistrationDelay);
 
-        registrations[1] = _createRegistration(SECRET_KEY_2, alice, unregistrationDelay);
+        registrations[1] = _createRegistration(SECRET_KEY_2, operator, unregistrationDelay);
 
-        bytes32 registrationRoot = registry.register{ value: collateral }(registrations, alice, unregistrationDelay);
+        bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator, unregistrationDelay);
 
         _assertRegistration(
             registrationRoot,
-            alice,
+            operator,
             uint56(collateral / 1 gwei),
             uint32(block.number),
             type(uint32).max,
@@ -244,13 +244,13 @@ contract RegistryTest is UnitTestHelper {
         uint256 collateral = 2 * minCollateral;
 
         IRegistry.Registration[] memory registrations = new IRegistry.Registration[](2);
-        registrations[0] = _createRegistration(SECRET_KEY_1, alice, unregistrationDelay);
+        registrations[0] = _createRegistration(SECRET_KEY_1, operator, unregistrationDelay);
 
-        registrations[1] = _createRegistration(SECRET_KEY_2, alice, unregistrationDelay);
+        registrations[1] = _createRegistration(SECRET_KEY_2, operator, unregistrationDelay);
 
         bytes32 registrationRoot = registry.register{ value: collateral }(
             registrations,
-            alice,
+            operator,
             unregistrationDelay + 1 // submit different delay than the one signed by validator key
         );
 
@@ -260,7 +260,7 @@ contract RegistryTest is UnitTestHelper {
         // Verify initial registration state
         _assertRegistration(
             registrationRoot,
-            alice,
+            operator,
             uint56(collateral / 1 gwei),
             uint32(block.number),
             type(uint32).max,
@@ -271,15 +271,15 @@ contract RegistryTest is UnitTestHelper {
         uint256 leafIndex = 0;
         bytes32[] memory proof = MerkleTree.generateProof(leaves, leafIndex);
 
-        uint256 bobBalanceBefore = bob.balance;
-        uint256 aliceBalanceBefore = alice.balance;
+        uint256 operatorBalanceBefore = operator.balance;
+        uint256 challengerBalanceBefore = challenger.balance;
         uint256 urcBalanceBefore = address(registry).balance;
 
-        vm.prank(bob);
+        vm.startPrank(challenger);
         uint256 rewardCollateralWei = registry.slashRegistration(registrationRoot, registrations[0], proof, leafIndex);
 
         _verifySlashingBalances(
-            bob, alice, 0, rewardCollateralWei, collateral, bobBalanceBefore, aliceBalanceBefore, urcBalanceBefore
+            challenger, operator, 0, rewardCollateralWei, collateral, challengerBalanceBefore, operatorBalanceBefore, urcBalanceBefore
         );
     }
 
@@ -288,40 +288,40 @@ contract RegistryTest is UnitTestHelper {
         uint256 collateral = 2 * minCollateral;
 
         IRegistry.Registration[] memory registrations = new IRegistry.Registration[](2);
-        registrations[0] = _createRegistration(SECRET_KEY_1, alice, unregistrationDelay);
+        registrations[0] = _createRegistration(SECRET_KEY_1, operator, unregistrationDelay);
 
-        registrations[1] = _createRegistration(SECRET_KEY_2, alice, unregistrationDelay);
+        registrations[1] = _createRegistration(SECRET_KEY_2, operator, unregistrationDelay);
 
         bytes32 registrationRoot = registry.register{ value: collateral }(
             registrations,
-            bob, // Bob tries to frontrun alice by setting his address as withdrawal address
+            thief, // thief tries to frontrun operator by setting his address as withdrawal address
             unregistrationDelay
         );
 
         // Verify initial registration state
         _assertRegistration(
             registrationRoot,
-            bob,
+            thief,
             uint56(collateral / 1 gwei),
             uint32(block.number),
             type(uint32).max,
             unregistrationDelay
         );
 
-        // Create proof for alice's registration
+        // Create proof for operator's registration
         bytes32[] memory leaves = _hashToLeaves(registrations);
         uint256 leafIndex = 0;
         bytes32[] memory proof = MerkleTree.generateProof(leaves, leafIndex);
 
-        uint256 bobBalanceBefore = bob.balance;
-        uint256 aliceBalanceBefore = alice.balance;
+        uint256 thiefBalanceBefore = thief.balance;
+        uint256 operatorBalanceBefore = operator.balance;
         uint256 urcBalanceBefore = address(registry).balance;
 
-        vm.prank(alice);
+        vm.startPrank(operator);
         uint256 rewardCollateralWei = registry.slashRegistration(registrationRoot, registrations[0], proof, leafIndex);
 
         _verifySlashingBalances(
-            alice, bob, 0, rewardCollateralWei, collateral, bobBalanceBefore, aliceBalanceBefore, urcBalanceBefore
+            operator, thief, 0, rewardCollateralWei, collateral, thiefBalanceBefore, operatorBalanceBefore, urcBalanceBefore
         );
     }
 
@@ -331,17 +331,17 @@ contract RegistryTest is UnitTestHelper {
 
         IRegistry.Registration[] memory registrations = new IRegistry.Registration[](3); // will be padded to 4
 
-        registrations[0] = _createRegistration(SECRET_KEY_1, alice, unregistrationDelay);
+        registrations[0] = _createRegistration(SECRET_KEY_1, operator, unregistrationDelay);
 
-        registrations[1] = _createRegistration(SECRET_KEY_1 + 1, alice, unregistrationDelay);
+        registrations[1] = _createRegistration(SECRET_KEY_1 + 1, operator, unregistrationDelay);
 
-        registrations[2] = _createRegistration(SECRET_KEY_1 + 2, alice, unregistrationDelay);
+        registrations[2] = _createRegistration(SECRET_KEY_1 + 2, operator, unregistrationDelay);
 
-        bytes32 registrationRoot = registry.register{ value: collateral }(registrations, alice, unregistrationDelay);
+        bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator, unregistrationDelay);
 
         _assertRegistration(
             registrationRoot,
-            alice,
+            operator,
             uint56(collateral / 1 gwei),
             uint32(block.number),
             type(uint32).max,
@@ -366,10 +366,10 @@ contract RegistryTest is UnitTestHelper {
 
         IRegistry.Registration[] memory registrations = new IRegistry.Registration[](size);
         for (uint256 i = 0; i < size; i++) {
-            registrations[i] = _createRegistration(SECRET_KEY_1 + i, alice, unregistrationDelay);
+            registrations[i] = _createRegistration(SECRET_KEY_1 + i, operator, unregistrationDelay);
         }
 
-        bytes32 registrationRoot = registry.register{ value: collateral }(registrations, alice, unregistrationDelay);
+        bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator, unregistrationDelay);
 
         bytes32[] memory leaves = _hashToLeaves(registrations);
 
@@ -388,28 +388,28 @@ contract RegistryTest is UnitTestHelper {
 
         IRegistry.Registration[] memory registrations = new IRegistry.Registration[](size);
         for (uint256 i = 0; i < size; i++) {
-            registrations[i] = _createRegistration(SECRET_KEY_1 + i, alice, unregistrationDelay);
+            registrations[i] = _createRegistration(SECRET_KEY_1 + i, operator, unregistrationDelay);
         }
 
         bytes32 registrationRoot = registry.register{ value: minCollateral }(
             registrations,
-            alice,
+            operator,
             unregistrationDelay + 1 // submit different delay than the one signed by validator keys
         );
 
         bytes32[] memory leaves = _hashToLeaves(registrations);
 
-        uint256 bobBalanceBefore = bob.balance;
-        uint256 aliceBalanceBefore = alice.balance;
+        uint256 thiefBalanceBefore = thief.balance;
+        uint256 operatorBalanceBefore = operator.balance;
         uint256 urcBalanceBefore = address(registry).balance;
 
         // Test all proof paths
         for (uint256 i = 0; i < leaves.length; i++) {
             bytes32[] memory proof = MerkleTree.generateProof(leaves, i);
-            vm.prank(bob);
+            vm.startPrank(operator);
             registry.slashRegistration(registrationRoot, registrations[i], proof, i);
             _verifySlashingBalances(
-                bob, alice, 0, minCollateral, minCollateral, bobBalanceBefore, aliceBalanceBefore, urcBalanceBefore
+                operator, thief, 0, minCollateral, minCollateral, thiefBalanceBefore, operatorBalanceBefore, urcBalanceBefore
             );
 
             _assertRegistration(registrationRoot, address(0), 0, 0, 0, 0);
@@ -417,13 +417,13 @@ contract RegistryTest is UnitTestHelper {
             // Re-register to reset the state
             registrationRoot = registry.register{ value: minCollateral }(
                 registrations,
-                alice,
+                operator,
                 unregistrationDelay + 1 // submit different delay than the one signed by validator keys
             );
 
             // update balances
-            bobBalanceBefore = bob.balance;
-            aliceBalanceBefore = alice.balance;
+            thiefBalanceBefore = thief.balance;
+            operatorBalanceBefore = operator.balance;
             urcBalanceBefore = address(registry).balance;
         }
     }
@@ -435,28 +435,28 @@ contract RegistryTest is UnitTestHelper {
 
         IRegistry.Registration[] memory registrations = new IRegistry.Registration[](size);
         for (uint256 i = 0; i < size; i++) {
-            registrations[i] = _createRegistration(SECRET_KEY_1 + i, alice, unregistrationDelay);
+            registrations[i] = _createRegistration(SECRET_KEY_1 + i, operator, unregistrationDelay);
         }
 
         bytes32 registrationRoot = registry.register{ value: minCollateral }(
             registrations,
-            bob, // submit different withdrawal address than the one signed by validator keys
+            thief, // submit different withdrawal address than the one signed by validator keys
             unregistrationDelay
         );
 
         bytes32[] memory leaves = _hashToLeaves(registrations);
 
-        uint256 bobBalanceBefore = bob.balance;
-        uint256 aliceBalanceBefore = alice.balance;
+        uint256 thiefBalanceBefore = thief.balance;
+        uint256 operatorBalanceBefore = operator.balance;
         uint256 urcBalanceBefore = address(registry).balance;
 
         // Test all proof paths
         for (uint256 i = 0; i < leaves.length; i++) {
             bytes32[] memory proof = MerkleTree.generateProof(leaves, i);
-            vm.prank(bob);
+            vm.startPrank(operator);
             registry.slashRegistration(registrationRoot, registrations[i], proof, i);
             _verifySlashingBalances(
-                bob, alice, 0, minCollateral, minCollateral, bobBalanceBefore, aliceBalanceBefore, urcBalanceBefore
+                operator, thief, 0, minCollateral, minCollateral, thiefBalanceBefore, operatorBalanceBefore, urcBalanceBefore
             );
 
             _assertRegistration(registrationRoot, address(0), 0, 0, 0, 0);
@@ -464,13 +464,13 @@ contract RegistryTest is UnitTestHelper {
             // Re-register to reset the state
             registrationRoot = registry.register{ value: minCollateral }(
                 registrations,
-                bob, // submit different withdrawal address than the one signed by validator keys
+                thief, // submit different withdrawal address than the one signed by validator keys
                 unregistrationDelay
             );
 
             // update balances
-            bobBalanceBefore = bob.balance;
-            aliceBalanceBefore = alice.balance;
+            thiefBalanceBefore = thief.balance;
+            operatorBalanceBefore = operator.balance;
             urcBalanceBefore = address(registry).balance;
         }
     }
@@ -480,11 +480,11 @@ contract RegistryTest is UnitTestHelper {
         uint256 collateral = 2 * minCollateral;
 
         IRegistry.Registration[] memory registrations =
-            _setupSingleRegistration(SECRET_KEY_1, alice, unregistrationDelay);
+            _setupSingleRegistration(SECRET_KEY_1, operator, unregistrationDelay);
 
-        bytes32 registrationRoot = registry.register{ value: collateral }(registrations, alice, unregistrationDelay);
+        bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator, unregistrationDelay);
 
-        vm.prank(alice);
+        vm.startPrank(operator);
         vm.expectEmit(address(registry));
         emit IRegistry.OperatorUnregistered(registrationRoot, uint32(block.number));
         registry.unregister(registrationRoot);
@@ -499,12 +499,12 @@ contract RegistryTest is UnitTestHelper {
         uint256 collateral = 2 * minCollateral;
 
         IRegistry.Registration[] memory registrations =
-            _setupSingleRegistration(SECRET_KEY_1, alice, unregistrationDelay);
+            _setupSingleRegistration(SECRET_KEY_1, operator, unregistrationDelay);
 
-        bytes32 registrationRoot = registry.register{ value: collateral }(registrations, alice, unregistrationDelay);
+        bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator, unregistrationDelay);
 
-        // Bob tries to unregister Alice's registration
-        vm.prank(bob);
+        // thief tries to unregister operator's registration
+        vm.startPrank(thief);
         vm.expectRevert(IRegistry.WrongOperator.selector);
         registry.unregister(registrationRoot);
     }
@@ -514,15 +514,15 @@ contract RegistryTest is UnitTestHelper {
         uint256 collateral = 2 * minCollateral;
 
         IRegistry.Registration[] memory registrations =
-            _setupSingleRegistration(SECRET_KEY_1, alice, unregistrationDelay);
+            _setupSingleRegistration(SECRET_KEY_1, operator, unregistrationDelay);
 
-        bytes32 registrationRoot = registry.register{ value: collateral }(registrations, alice, unregistrationDelay);
+        bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator, unregistrationDelay);
 
-        vm.prank(alice);
+        vm.startPrank(operator);
         registry.unregister(registrationRoot);
 
         // Try to unregister again
-        vm.prank(alice);
+        vm.startPrank(operator);
         vm.expectRevert(IRegistry.AlreadyUnregistered.selector);
         registry.unregister(registrationRoot);
     }
@@ -532,24 +532,24 @@ contract RegistryTest is UnitTestHelper {
         uint256 collateral = 2 * minCollateral;
 
         IRegistry.Registration[] memory registrations =
-            _setupSingleRegistration(SECRET_KEY_1, alice, unregistrationDelay);
+            _setupSingleRegistration(SECRET_KEY_1, operator, unregistrationDelay);
 
-        bytes32 registrationRoot = registry.register{ value: collateral }(registrations, alice, unregistrationDelay);
+        bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator, unregistrationDelay);
 
-        vm.prank(alice);
+        vm.startPrank(operator);
         registry.unregister(registrationRoot);
 
         // Wait for unregistration delay
         vm.roll(block.number + unregistrationDelay);
 
-        uint256 balanceBefore = alice.balance;
+        uint256 balanceBefore = operator.balance;
 
-        vm.prank(alice);
+        vm.startPrank(operator);
         vm.expectEmit(address(registry));
         emit IRegistry.CollateralClaimed(registrationRoot, uint256(collateral / 1 gwei));
         registry.claimCollateral(registrationRoot);
 
-        assertEq(alice.balance, balanceBefore + collateral, "Collateral not returned");
+        assertEq(operator.balance, balanceBefore + collateral, "Collateral not returned");
 
         // Verify registration was deleted
         (address withdrawalAddress,,,,) = registry.registrations(registrationRoot);
@@ -561,12 +561,12 @@ contract RegistryTest is UnitTestHelper {
         uint256 collateral = 2 * minCollateral;
 
         IRegistry.Registration[] memory registrations =
-            _setupSingleRegistration(SECRET_KEY_1, alice, unregistrationDelay);
+            _setupSingleRegistration(SECRET_KEY_1, operator, unregistrationDelay);
 
-        bytes32 registrationRoot = registry.register{ value: collateral }(registrations, alice, unregistrationDelay);
+        bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator, unregistrationDelay);
 
         // Try to claim without unregistering first
-        vm.prank(alice);
+        vm.startPrank(operator);
         vm.expectRevert(IRegistry.NotUnregistered.selector);
         registry.claimCollateral(registrationRoot);
     }
@@ -576,17 +576,17 @@ contract RegistryTest is UnitTestHelper {
         uint256 collateral = 2 * minCollateral;
 
         IRegistry.Registration[] memory registrations =
-            _setupSingleRegistration(SECRET_KEY_1, alice, unregistrationDelay);
+            _setupSingleRegistration(SECRET_KEY_1, operator, unregistrationDelay);
 
-        bytes32 registrationRoot = registry.register{ value: collateral }(registrations, alice, unregistrationDelay);
+        bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator, unregistrationDelay);
 
-        vm.prank(alice);
+        vm.startPrank(operator);
         registry.unregister(registrationRoot);
 
         // Try to claim before delay has passed
         vm.roll(block.number + unregistrationDelay - 1);
 
-        vm.prank(alice);
+        vm.startPrank(operator);
         vm.expectRevert(IRegistry.UnregistrationDelayNotMet.selector);
         registry.claimCollateral(registrationRoot);
     }
@@ -596,20 +596,20 @@ contract RegistryTest is UnitTestHelper {
         uint256 collateral = 2 * minCollateral;
 
         IRegistry.Registration[] memory registrations =
-            _setupSingleRegistration(SECRET_KEY_1, alice, unregistrationDelay);
+            _setupSingleRegistration(SECRET_KEY_1, operator, unregistrationDelay);
 
-        bytes32 registrationRoot = registry.register{ value: collateral }(registrations, alice, unregistrationDelay);
+        bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator, unregistrationDelay);
 
-        vm.prank(alice);
+        vm.startPrank(operator);
         registry.unregister(registrationRoot);
 
         vm.roll(block.number + unregistrationDelay);
 
-        vm.prank(alice);
+        vm.startPrank(operator);
         registry.claimCollateral(registrationRoot);
 
         // Try to claim again
-        vm.prank(alice);
+        vm.startPrank(operator);
         vm.expectRevert(IRegistry.NoCollateralToClaim.selector);
         registry.claimCollateral(registrationRoot);
     }
@@ -620,13 +620,13 @@ contract RegistryTest is UnitTestHelper {
         vm.assume((addAmount + collateral) / 1 gwei < uint256(2 ** 56));
 
         IRegistry.Registration[] memory registrations =
-            _setupSingleRegistration(SECRET_KEY_1, alice, unregistrationDelay);
+            _setupSingleRegistration(SECRET_KEY_1, operator, unregistrationDelay);
 
-        bytes32 registrationRoot = registry.register{ value: collateral }(registrations, alice, unregistrationDelay);
+        bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator, unregistrationDelay);
 
         uint256 expectedCollateralGwei = (collateral + addAmount) / 1 gwei;
-        vm.deal(alice, addAmount);
-        vm.prank(alice);
+        vm.deal(operator, addAmount);
+        vm.startPrank(operator);
 
         vm.expectEmit(address(registry));
         emit IRegistry.CollateralAdded(registrationRoot, expectedCollateralGwei);
@@ -641,13 +641,13 @@ contract RegistryTest is UnitTestHelper {
         uint256 collateral = 2 * minCollateral;
 
         IRegistry.Registration[] memory registrations =
-            _setupSingleRegistration(SECRET_KEY_1, alice, unregistrationDelay);
+            _setupSingleRegistration(SECRET_KEY_1, operator, unregistrationDelay);
 
-        bytes32 registrationRoot = registry.register{ value: collateral }(registrations, alice, unregistrationDelay);
+        bytes32 registrationRoot = registry.register{ value: collateral }(registrations, operator, unregistrationDelay);
 
         uint256 addAmount = 2 ** 56 * 1 gwei; // overflow uint56
-        vm.deal(alice, addAmount);
-        vm.prank(alice);
+        vm.deal(operator, addAmount);
+        vm.startPrank(operator);
 
         vm.expectRevert(IRegistry.CollateralOverflow.selector);
         registry.addCollateral{ value: addAmount }(registrationRoot);
@@ -715,9 +715,9 @@ contract RegistryTest is UnitTestHelper {
         (uint16 unregistrationDelay,) = _setupBasicRegistrationParams();
         IRegistry.Registration[] memory registrations = new IRegistry.Registration[](1);
 
-        registrations[0] = _createRegistration(SECRET_KEY_1, bob, unregistrationDelay);
+        registrations[0] = _createRegistration(SECRET_KEY_1, operator, unregistrationDelay);
 
-        // set operator's withdrawal address to reentrantContract
+        // frontrun to set withdrawal address to reentrantContract
         reentrantContract.register(registrations, unregistrationDelay);
 
         _assertRegistration(
@@ -733,8 +733,8 @@ contract RegistryTest is UnitTestHelper {
         bytes32[] memory leaves = _hashToLeaves(registrations);
         bytes32[] memory proof = MerkleTree.generateProof(leaves, 0);
 
-        // bob can slash the registration
-        vm.startPrank(bob);
+        // operator can slash the registration
+        vm.startPrank(operator);
         uint256 slashedCollateralWei = registry.slashRegistration(
             reentrantContract.registrationRoot(),
             registrations[0],

--- a/test/Slasher.t.sol
+++ b/test/Slasher.t.sol
@@ -35,7 +35,8 @@ contract DummySlasherTest is UnitTestHelper {
     function setUp() public {
         registry = new Registry();
         dummySlasher = new DummySlasher();
-        vm.deal(alice, 100 ether); // Give alice some ETH
+        vm.deal(operator, 100 ether);
+        vm.deal(challenger, 100 ether);
         delegatePubKey = BLS.toPublicKey(SECRET_KEY_2);
     }
 
@@ -43,7 +44,7 @@ contract DummySlasherTest is UnitTestHelper {
         RegisterAndDelegateParams memory params = RegisterAndDelegateParams({
             proposerSecretKey: SECRET_KEY_1,
             collateral: collateral,
-            withdrawalAddress: alice,
+            withdrawalAddress: operator,
             delegateSecretKey: SECRET_KEY_2,
             slasher: address(dummySlasher),
             domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
@@ -62,12 +63,11 @@ contract DummySlasherTest is UnitTestHelper {
         // skip past fraud proof window
         vm.roll(block.timestamp + registry.FRAUD_PROOF_WINDOW() + 1);
 
-        uint256 bobBalanceBefore = bob.balance;
-        uint256 aliceBalanceBefore = alice.balance;
+        uint256 challengerBalanceBefore = challenger.balance;
+        uint256 operatorBalanceBefore = operator.balance;
         uint256 urcBalanceBefore = address(registry).balance;
 
-        // slash from a different address
-        vm.startPrank(bob);
+        vm.startPrank(challenger);
         vm.expectEmit(address(registry));
         emit IRegistry.OperatorSlashed(
             result.registrationRoot,
@@ -75,6 +75,7 @@ contract DummySlasherTest is UnitTestHelper {
             dummySlasher.REWARD_AMOUNT_GWEI(),
             result.signedDelegation.delegation.proposerPubKey
         );
+        
         (uint256 gotSlashAmountGwei, uint256 gotRewardAmountGwei) = registry.slashCommitment(
             result.registrationRoot,
             result.registrations[leafIndex].signature,
@@ -83,21 +84,18 @@ contract DummySlasherTest is UnitTestHelper {
             result.signedDelegation,
             evidence
         );
-        assertEq(dummySlasher.SLASH_AMOUNT_GWEI(), gotSlashAmountGwei, "Slash amount incorrect");
 
-        // verify balances updated correctly
         _verifySlashingBalances(
-            bob,
-            alice,
+            challenger,
+            operator,
             dummySlasher.SLASH_AMOUNT_GWEI() * 1 gwei,
             dummySlasher.REWARD_AMOUNT_GWEI() * 1 gwei,
             collateral,
-            bobBalanceBefore,
-            aliceBalanceBefore,
+            challengerBalanceBefore,
+            operatorBalanceBefore,
             urcBalanceBefore
         );
 
-        // Verify operator was deleted
         _assertRegistration(result.registrationRoot, address(0), 0, 0, 0, 0);
     }
 
@@ -105,7 +103,7 @@ contract DummySlasherTest is UnitTestHelper {
         RegisterAndDelegateParams memory params = RegisterAndDelegateParams({
             proposerSecretKey: SECRET_KEY_1,
             collateral: collateral,
-            withdrawalAddress: alice,
+            withdrawalAddress: operator,
             delegateSecretKey: SECRET_KEY_2,
             slasher: address(dummySlasher),
             domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
@@ -136,7 +134,7 @@ contract DummySlasherTest is UnitTestHelper {
         RegisterAndDelegateParams memory params = RegisterAndDelegateParams({
             proposerSecretKey: SECRET_KEY_1,
             collateral: collateral,
-            withdrawalAddress: alice,
+            withdrawalAddress: operator,
             delegateSecretKey: SECRET_KEY_2,
             slasher: address(dummySlasher),
             domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
@@ -162,7 +160,7 @@ contract DummySlasherTest is UnitTestHelper {
         RegisterAndDelegateParams memory params = RegisterAndDelegateParams({
             proposerSecretKey: SECRET_KEY_1,
             collateral: collateral,
-            withdrawalAddress: alice,
+            withdrawalAddress: operator,
             delegateSecretKey: SECRET_KEY_2,
             slasher: address(dummySlasher),
             domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
@@ -197,7 +195,7 @@ contract DummySlasherTest is UnitTestHelper {
         RegisterAndDelegateParams memory params = RegisterAndDelegateParams({
             proposerSecretKey: SECRET_KEY_1,
             collateral: dummySlasher.SLASH_AMOUNT_GWEI() * 1 gwei - 1, // less than the slash amount
-            withdrawalAddress: alice,
+            withdrawalAddress: operator,
             delegateSecretKey: SECRET_KEY_2,
             slasher: address(dummySlasher),
             domainSeparator: dummySlasher.DOMAIN_SEPARATOR(),
@@ -213,7 +211,7 @@ contract DummySlasherTest is UnitTestHelper {
 
         vm.roll(block.timestamp + registry.FRAUD_PROOF_WINDOW() + 1);
 
-        vm.startPrank(bob);
+        vm.startPrank(challenger);
         vm.expectRevert(IRegistry.SlashAmountExceedsCollateral.selector);
         registry.slashCommitment(
             result.registrationRoot,
@@ -285,12 +283,12 @@ contract DummySlasherTest is UnitTestHelper {
         // skip past fraud proof window
         vm.roll(block.timestamp + registry.FRAUD_PROOF_WINDOW() + 1);
 
-        uint256 aliceBalanceBefore = alice.balance;
+        uint256 challengerBalanceBefore = challenger.balance;
         uint256 reentrantContractBalanceBefore = reentrantContract.balance;
         uint256 urcBalanceBefore = address(registry).balance;
 
         // slash from a different address
-        vm.startPrank(alice);
+        vm.startPrank(challenger);
         vm.expectEmit(address(registry));
         emit IRegistry.OperatorSlashed(
             result.registrationRoot,
@@ -305,12 +303,12 @@ contract DummySlasherTest is UnitTestHelper {
 
         // verify balances updated correctly
         _verifySlashingBalances(
-            alice,
+            challenger,
             address(reentrantContract),
             dummySlasher.SLASH_AMOUNT_GWEI() * 1 gwei,
             dummySlasher.REWARD_AMOUNT_GWEI() * 1 gwei,
             IReentrantContract(reentrantContract).collateral(),
-            aliceBalanceBefore,
+            challengerBalanceBefore,
             reentrantContractBalanceBefore,
             urcBalanceBefore
         );

--- a/test/Slasher.t.sol
+++ b/test/Slasher.t.sol
@@ -18,7 +18,7 @@ contract DummySlasher is ISlasher {
         return bytes("DUMMY-SLASHER-DOMAIN-SEPARATOR");
     }
 
-    function slash(ISlasher.Delegation calldata delegation, bytes calldata evidence)
+    function slash(ISlasher.Delegation calldata delegation, bytes calldata evidence, address challenger)
         external
         returns (uint256 slashAmountGwei, uint256 rewardAmountGwei)
     {

--- a/test/UnitTestHelper.sol
+++ b/test/UnitTestHelper.sol
@@ -11,11 +11,10 @@ contract UnitTestHelper is Test {
     using BLS for *;
 
     Registry registry;
-    address alice = makeAddr("alice");
-    address bob = makeAddr("bob");
     address operator = makeAddr("operator");
     address challenger = makeAddr("challenger");
     address delegate = makeAddr("delegate");
+    address thief = makeAddr("thief");
 
     // Preset secret keys for deterministic testing
     uint256 constant SECRET_KEY_1 = 12345;

--- a/test/UnitTestHelper.sol
+++ b/test/UnitTestHelper.sol
@@ -13,6 +13,9 @@ contract UnitTestHelper is Test {
     Registry registry;
     address alice = makeAddr("alice");
     address bob = makeAddr("bob");
+    address operator = makeAddr("operator");
+    address challenger = makeAddr("challenger");
+    address delegate = makeAddr("delegate");
 
     // Preset secret keys for deterministic testing
     uint256 constant SECRET_KEY_1 = 12345;
@@ -89,22 +92,22 @@ contract UnitTestHelper is Test {
     }
 
     function _verifySlashingBalances(
-        address challenger,
-        address operator,
-        uint256 slashedAmount,
-        uint256 rewardAmount,
-        uint256 totalCollateral,
-        uint256 challengerBalanceBefore,
-        uint256 operatorBalanceBefore,
-        uint256 urcBalanceBefore
+        address _challenger,
+        address _operator,
+        uint256 _slashedAmount,
+        uint256 _rewardAmount,
+        uint256 _totalCollateral,
+        uint256 _challengerBalanceBefore,
+        uint256 _operatorBalanceBefore,
+        uint256 _urcBalanceBefore
     ) internal view {
-        assertEq(challenger.balance, challengerBalanceBefore + rewardAmount, "challenger didn't receive reward");
+        assertEq(_challenger.balance, _challengerBalanceBefore + _rewardAmount, "challenger didn't receive reward");
         assertEq(
-            operator.balance,
-            operatorBalanceBefore + totalCollateral - slashedAmount - rewardAmount,
+            _operator.balance,
+            _operatorBalanceBefore + _totalCollateral - _slashedAmount - _rewardAmount,
             "operator didn't receive remaining funds"
         );
-        assertEq(address(registry).balance, urcBalanceBefore - totalCollateral, "urc balance incorrect");
+        assertEq(address(registry).balance, _urcBalanceBefore - _totalCollateral, "urc balance incorrect");
     }
 
     function basicRegistration(uint256 secretKey, uint256 collateral, address withdrawalAddress)


### PR DESCRIPTION
Add an example implementation of a basic Slasher contract for inclusion preconfs. In implementing this two breaking changes were made:

- `delegation.validUntil` check was removed from `slashCommitment()` to account for 2-step slashing use cases as needed by the inclusion preconf slasher's fraud proof
- a `challenger` parameter was added to the `ISlasher.Slash()` interface to prevent race conditions when dealing with 2-step slashing use cases

Other additions:
- improved test clarity by changing 'alice' and 'bob' with 'operator' and 'challenger'
- closes 14