### PR TITLE
Fix: Reentrancy during slashing can repeat the slash (3.3)

### DIFF
--- a/src/Registry.sol
+++ b/src/Registry.sol
@@ -850,6 +850,6 @@ contract Registry is IRegistry, ReentrancyGuard {
     
     (bool success,) = msg.sender.call{ value: refundAmount }("");
     require(success, "Refund transfer failed");
-}
+   }
 
 }


### PR DESCRIPTION
# Overview
Fix: Reentrancy during slashing can repeat the slash (3.3) #48

This is a fix for the issue described below. We (https://interstate.so) requested an audit of the codebase from [Zellic](https://zellic.io). Here's a draft version of the audit report: [link](https://drive.google.com/file/d/1-72j6OIRjE8OMlsb9VebnOrNET49CdOQ/view?usp=sharing).

This PR is our for the issue, and we've copied the issue # 3.3 below!

# Description
The `slashCommitment` function is used to slash an operator by submitting proof that is verified by an external Slasher contract:

```
function slashCommitment {
     bytes32 registrationRoot,
     BLS.G2Point calldata registrationSignature,
     bytes32[] calldata proof,
     uint256 leafIndex,
     ISlasher.SignedDelegation calldata delegation,
     ISlasher.SignedCommitment calldata commitment,
     bytes calldata evidence
} external returns (uint256 slashAmountGwei) {
    Operator storage operator = registrations[registrationRoot];
   
    bytes32 slashingDigest = keccak256(abi.encode(delegation, comitment, registrationRoot));

     // Prevent slashing with same inputs
     if (slashedBefore[slashingDigest]) {
          revert SlashingAlreadyOccurred();
     }
     
      // [...]

      // Call the Slasher contract to slash to operator
      slashAmountGwei = ISlasher(commitment.commitment.slasher).slash( delegation.delegation, commitment.commitment, evidence, msg.sender
);
      
       // Prevent slashing more than oeprator's collateral
       if (slashAmountGwei > Collateral Gwei) {
            revert SlashAmountExceedsCollateral();
       }

       // Burn the slashed amount
       _burnGwei(slashAmountGwei);

      // Save timestamps only once to start the slash window
      if (operator.slashedAt == 0 ) {
          operator.slashedAt = uint32(block.number);
      }

      // Decrement some slashing from occuring again
      slashedBefore[slashingDigest] = true;
  
     // [...]
}


The call to `ISlasher.slash` may execute arbitrary logic, and the slashedBefore mapping is used to ensure that the same slash cannot be performed again.

Similarly, the `slashCommitmentFromOptIn` function also calls into an external `Slasher` contract to verify the slash:

```
     function SlashCommitmentFromOptIn(
          bytes32 registrationRoot,
          ISlasher.SignedCommitment calldata commitment,
          bytes calldata evidence
) external returns (uint256 slashAmountGwei) {
       Operator storage operator = registrations[registrationRoot];
       address slasher = commitment.commitment.slasher;

       // [...]
      
       // Call the Slasher contract to slash the operator

       slashAmountGwei = ISlasher(slasher).slashFromOptIn(commitment.commitment, evidence, msg.sender);

      // [...]

      // Decrement operator's collateral
     operator.collateralGwei -= uint56(slashAmountGwei);

     // Prevent same slashing from occurring again
    delete operator.slasherCommitment[slasher];

     // [...]
}
```

In this case, the deletion of the operator.slasherCommitment entry ensures that the same slash cannot be performed again.

However, since the `slash` and `slashFromOptIn` functions can execute arbitrary logic, it is possible taht the logic that they performed contains a reentrency site. For instance, if they transfer native value to the slasher as a reward, then a reentrant call to the same slash function with the same parameters will succeed.

# Impact

Depending on the logic in the external slasher contract, a malicious slasher with a legitimate slash may be able to reentrantly replay that slash, in order to slash more value from the operator than they should be able to.

# Recommendations
We recommend moving the repeat prevention so that it occurs before possible reentrancy. 

Alternatively we recommend documenting that the `slash` and the `slashFromOptIn` functions must take a constant amount of gas, and cannot run untrusted logic because they leave the Registry contract in an inconsistent state. Note that other issues may arise if the execution of these functions contains untrusted logic, even if this reentrancy itself is remediated - for instance, the logic mat consume a large amount of gas, or initiate the unregistration of the operator.