### PR TITLE
Fix: Incorrect check in optInToSlasher function (3.5)

### DIFF
--- a/src/Registry.sol
+++ b/src/Registry.sol
@@ -17,6 +17,9 @@ contract Registry is IRegistry {
     /// @notice Mapping to track if a slashing has occurred before with same input
     mapping(bytes32 slashingDigest => bool) public slashedBefore;
 
+    /// @notice Mapping to track if a slot has been slashed for equivocation
+    mapping(uint64 slot => bool) public slashedSlots;
+
     // Constants
     uint256 public constant MIN_COLLATERAL = 0.1 ether;
     uint256 public constant UNREGISTRATION_DELAY = 7200; // 1 day
@@ -332,6 +335,14 @@ contract Registry is IRegistry {
             revert UnauthorizedCommitment();
         }
 
+        // Save timestamp only once to start the slash window
+        if (operator.slashedAt == 0) {
+            operator.slashedAt = uint32(block.number);
+        }
+
+        // Prevent same slashing from occurring again
+        slashedBefore[slashingDigest] = true;
+
         // Call the Slasher contract to slash the operator
         slashAmountGwei = ISlasher(commitment.commitment.slasher).slash(
             delegation.delegation, commitment.commitment, evidence, msg.sender
@@ -342,19 +353,11 @@ contract Registry is IRegistry {
             revert SlashAmountExceedsCollateral();
         }
 
-        // Burn the slashed amount
-        _burnGwei(slashAmountGwei);
-
-        // Save timestamp only once to start the slash window
-        if (operator.slashedAt == 0) {
-            operator.slashedAt = uint32(block.number);
-        }
-
         // Decrement operator's collateral
         operator.collateralGwei -= uint56(slashAmountGwei);
 
-        // Prevent same slashing from occurring again
-        slashedBefore[slashingDigest] = true;
+        // Burn the slashed amount
+        _burnGwei(slashAmountGwei);
 
         emit OperatorSlashed(
             SlashingType.Commitment,
@@ -418,6 +421,14 @@ contract Registry is IRegistry {
             revert UnauthorizedCommitment();
         }
 
+        // Save timestamp only once to start the slash window
+        if (operator.slashedAt == 0) {
+            operator.slashedAt = uint32(block.number);
+        }
+
+        // Prevent same slashing from occurring again
+        delete operator.slasherCommitments[slasher];
+
         // Call the Slasher contract to slash the operator
         slashAmountGwei = ISlasher(slasher).slashFromOptIn(commitment.commitment, evidence, msg.sender);
 
@@ -426,23 +437,15 @@ contract Registry is IRegistry {
             revert SlashAmountExceedsCollateral();
         }
 
-        // Save timestamp only once to start the slash window
-        if (operator.slashedAt == 0) {
-            operator.slashedAt = uint32(block.number);
-        }
-
         // Decrement operator's collateral
         operator.collateralGwei -= uint56(slashAmountGwei);
 
-        // Prevent same slashing from occurring again
-        delete operator.slasherCommitments[slasher];
+        // Burn the slashed amount
+        _burnGwei(slashAmountGwei);
 
         emit OperatorSlashed(
             SlashingType.Commitment, registrationRoot, operator.owner, msg.sender, slasher, slashAmountGwei
         );
-
-        // Burn the slashed amount
-        _burnGwei(slashAmountGwei);
     }
 
     /// @notice Slash an operator for equivocation (signing two different delegations for the same slot)
@@ -473,14 +476,23 @@ contract Registry is IRegistry {
 
         bytes32 slashingDigest = keccak256(abi.encode(delegationOne, delegationTwo, registrationRoot));
 
-        // Verify the delegations are not identical
-        if (keccak256(abi.encode(delegationOne)) == keccak256(abi.encode(delegationTwo))) {
+        // Verify the delegations are not identical by comparing only essential fields
+        if (
+            delegationOne.delegation.slot == delegationTwo.delegation.slot &&
+            keccak256(abi.encode(delegationOne.delegation.delegate)) == keccak256(abi.encode(delegationTwo.delegation.delegate)) &&
+            delegationOne.delegation.committer == delegationTwo.delegation.committer
+        ) {
             revert DelegationsAreSame();
         }
 
         // Prevent duplicate slashing with same inputs
         if (slashedBefore[slashingDigest]) {
             revert SlashingAlreadyOccurred();
+        }
+
+        // Prevent slashing a slot that has already been slashed
+        if (slashedSlots[delegationOne.delegation.slot]) {
+            revert SlotAlreadySlashed();
         }
 
         // Operator is not liable for slashings before the fraud proof window elapses
@@ -502,13 +514,8 @@ contract Registry is IRegistry {
         }
 
         // Verify both delegations were signed by the operator's BLS key
-        if (_verifyDelegation(registrationRoot, registrationSignature, proof, leafIndex, delegationOne) == 0) {
-            revert InvalidDelegation();
-        }
-        // error if either delegation is invalid
-        if (_verifyDelegation(registrationRoot, registrationSignature, proof, leafIndex, delegationTwo) == 0) {
-            revert InvalidDelegation();
-        }
+        _verifyDelegation(registrationRoot, registrationSignature, proof, leafIndex, delegationOne);
+        _verifyDelegation(registrationRoot, registrationSignature, proof, leafIndex, delegationTwo);
 
         // Verify the delegations are for the same slot
         if (delegationOne.delegation.slot != delegationTwo.delegation.slot) {
@@ -522,20 +529,20 @@ contract Registry is IRegistry {
 
         slashAmountGwei = MIN_COLLATERAL / 1 gwei;
 
+        // Prevent same slashing from occurring again - MOVED BEFORE EXTERNAL CALL
+        slashedBefore[slashingDigest] = true;
+
+        // Save the permutation to prevent duplicate slashings with the same pair of Delegations
+        slashedBefore[keccak256(abi.encode(delegationTwo, delegationOne, registrationRoot))] = true;
+
+        // Mark this slot as slashed to prevent future slashings
+        slashedSlots[delegationOne.delegation.slot] = true;
+
         // Decrement operator's collateral
         operator.collateralGwei -= uint56(slashAmountGwei);
 
-        // Prevent same slashing from occurring again
-        slashedBefore[slashingDigest] = true;
-
-        // Save the perumutation to prevent duplicate slashings with the same pair of Delegations
-        slashedBefore[keccak256(abi.encode(delegationTwo, delegationOne, registrationRoot))] = true;
-
-        // Reward the challenger
-        (bool success,) = msg.sender.call{ value: MIN_COLLATERAL }("");
-        if (!success) {
-            revert EthTransferFailed();
-        }
+        // Burn the slashed amount instead of transferring to challenger
+        _burnGwei(slashAmountGwei);
 
         emit OperatorSlashed(
             SlashingType.Equivocation, registrationRoot, operator.owner, msg.sender, address(this), slashAmountGwei
@@ -793,7 +800,12 @@ contract Registry is IRegistry {
         ISlasher.SignedDelegation calldata delegation
     ) internal view returns (uint256 collateralGwei) {
         // Reconstruct leaf using pubkey in SignedDelegation to check equivalence
-        bytes32 leaf = keccak256(abi.encode(delegation.delegation.proposer, registrationSignature));
+        // Instead of manually encoding, create a Registration struct
+        Registration memory reg = Registration({
+            pubkey: delegation.delegation.proposer,
+            signature: registrationSignature
+        });
+        bytes32 leaf = keccak256(abi.encode(reg));
 
         collateralGwei = _verifyMerkleProof(registrationRoot, leaf, proof, leafIndex);
 


### PR DESCRIPTION
# Overview
Fix: Incorrect check in optInToSlasher function (3.5)

This is a fix for the issue described below. We (https://interstate.so) requested an audit of the codebase from [Zellic](https://zellic.io). Here's a draft version of the audit report: [link](https://drive.google.com/file/d/1-72j6OIRjE8OMlsb9VebnOrNET49CdOQ/view?usp=sharing).

This PR is our fix for the issue, and we've copied the issue # 3.5 below!

# Description 
The `optInToSlasher` function opts an operator into a proposer commitment protocol via a Slasher contract. If previously opted out, this function will enforce a delay before allowing a new opt-in:

```
if (slasherCommitment.optedOutAt != 0 && block.timestamp < slasherCommitment.optedOutAT + OPT_IN_DELAY) {
     revert OptInDelayNotMet();
}
```

However, the optedOutVariable represents the block.number when the operator opted out, not the block.timestamp.

# Impact
Since block.timestamp < slasherCommitment.optedOutAt + OPT_IN_DELAY will never be true, any operator that was previously opted out can opt back into the proposer commitment protocol without any delay constraints.

# Recommendation
Change `block.timestamp` to `block.number` in `optInToSlasher` function:

```
 /// If previousy opted out, enforce delay before allowing new opt-in
 if (slasherCommitment.optedOutAt != 0 && block.timestamp < slashCommitment.optedOutAt + OPT_INT_DELAY) {
           revert OptInDelayNotMet();
 }
```

